### PR TITLE
Change from django-compressor alpha to release version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ git+git://github.com/refreshoxford/django-pygments@master#egg=django_pygments
 blessings==1.3
 psycopg2==2.4.4
 south==0.7.3
-#django_compressor 1.2 is currently pre-release, so get 1.2a1 from pypi.
-django-compressor==1.2a1
+django-compressor==1.2
 django-extensions==0.7.1
 gunicorn==0.13.4
 werkzeug==0.8.3


### PR DESCRIPTION
requirements.txt was using django-compressor alpha: this is not only not required any more but it no longer worked
