### PR TITLE
Make version-change links go to Klass if it exists

### DIFF
--- a/cbv/templates/cbv/includes/nav.html
+++ b/cbv/templates/cbv/includes/nav.html
@@ -8,7 +8,7 @@
         <ul class="dropdown-menu">
             {% for v in other_versions %}
                 <li>
-                    <a href="{{ v.get_absolute_url }}">{{ v }}</a>
+                    <a href="{{ v.url|default:v.get_absolute_url }}">{{ v }}</a>
                 </li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
The nav bar has links to each other ProjectVersion, but these just went
to the version's detail page. This links to the version's instance of
the current Klass, if it exists.
