### PR TITLE
Listing os libs on readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,7 +45,7 @@ Tools to consider
 Installation
 ------------
 
-First you should install some OS libraries required for some packages, this can vary on each OS, but if you're on Ubuntu, then this should do the trick for you:
+First you should install some OS libraries required for some packages, this can vary with each OS, but if you're on Ubuntu 14.04, then this should do the trick for you:
 
     sudo apt-get install python-dev libmemcached-dev zlib1g-dev libpq-dev
 


### PR DESCRIPTION
Found out that only this one where required:

python-dev,  libmemcached-dev and zlib1g-dev (for memcached), libpq-dev (for Postgres)
This are the ones on Ubuntu (I used a Ubuntu:14.04 docker image to check this, since it's a very common OS).
Anyway, if someone don't use this OS they can also check for their equivalents.
this should fix #95
