### PR TITLE
Remove database queries from nav template

### DIFF
--- a/cbv/templates/cbv/includes/nav.html
+++ b/cbv/templates/cbv/includes/nav.html
@@ -19,19 +19,19 @@
         <li class="divider-vertical"></li>
         <li><a href="#">{{ module.source_name }}</a></li>
     {% endifchanged %}
-    {% if module.klass_set.count == 1 %}
-        {% with klass=module.klass_set.get %}
+    {% if module.classes|length == 1 %}
+        {% with klass=module.classes.0 %}
             <li {% if klass == this_klass %}class=" active"{% endif %}>
                 <a href="{{ klass.get_absolute_url }}">{{ klass }}</a>
             </li>
         {% endwith %}
     {% else %}
-        <li id="module-{{ module.short_name }}" class="dropdown{% if module == this_module %} active{% endif %}">
+        <li id="module-{{ module.short_name }}" class="dropdown{% if module.active %} active{% endif %}">
             <a href="#module-{{ module.short_name }}" class="dropdown-toggle" data-toggle="dropdown">
                 {{ module.short_name|title }} <b class="caret"></b>
             </a>
             <ul class="dropdown-menu">
-                {% for klass in module.klass_set.all %}
+                {% for klass in module.classes %}
                     <li {% if klass == this_klass %}class=" active"{% endif %}>
                         <a href="{{ klass.get_absolute_url }}">{{ klass }}</a>
                     </li>

--- a/cbv/templates/cbv/includes/nav.html
+++ b/cbv/templates/cbv/includes/nav.html
@@ -21,8 +21,8 @@
     {% endifchanged %}
     {% if module.classes|length == 1 %}
         {% with klass=module.classes.0 %}
-            <li {% if klass == this_klass %}class=" active"{% endif %}>
-                <a href="{{ klass.get_absolute_url }}">{{ klass }}</a>
+            <li {% if klass.active %}class=" active"{% endif %}>
+                <a href="{{ klass.url }}">{{ klass.name }}</a>
             </li>
         {% endwith %}
     {% else %}
@@ -32,8 +32,8 @@
             </a>
             <ul class="dropdown-menu">
                 {% for klass in module.classes %}
-                    <li {% if klass == this_klass %}class=" active"{% endif %}>
-                        <a href="{{ klass.get_absolute_url }}">{{ klass }}</a>
+                    <li {% if klass.active %}class=" active"{% endif %}>
+                        <a href="{{ klass.url }}">{{ klass.name }}</a>
                     </li>
                 {% endfor %}
             </ul>

--- a/cbv/templates/cbv/includes/nav.html
+++ b/cbv/templates/cbv/includes/nav.html
@@ -8,7 +8,7 @@
         <ul class="dropdown-menu">
             {% for v in other_versions %}
                 <li>
-                    <a href="{{ v.url|default:v.get_absolute_url }}">{{ v }}</a>
+                    <a href="{{ v.url }}">{{ v.name }}</a>
                 </li>
             {% endfor %}
         </ul>

--- a/cbv/templates/cbv/includes/nav.html
+++ b/cbv/templates/cbv/includes/nav.html
@@ -1,3 +1,5 @@
+{% load sansdb %}
+{% sansdb %}
 <li li="version-{{ version.version_number }}" class="dropdown">
     {% if not other_versions %}
         <a href="#">{{ version }}</a>
@@ -40,3 +42,4 @@
         </li>
     {% endif %}
 {% endfor %}
+{% endsansdb %}

--- a/cbv/templates/cbv/includes/nav.html
+++ b/cbv/templates/cbv/includes/nav.html
@@ -14,7 +14,7 @@
         </ul>
     {% endif %}
 </li>
-{% for module in version.module_set.all %}
+{% for module in modules %}
     {% ifchanged module.source_name %}
         <li class="divider-vertical"></li>
         <li><a href="#">{{ module.source_name }}</a></li>

--- a/cbv/templatetags/cbv_tags.py
+++ b/cbv/templatetags/cbv_tags.py
@@ -35,6 +35,14 @@ class OtherVersion:
     url: str
 
 
+@attrs.frozen
+class ModuleData:
+    source_name: str
+    short_name: str
+    classes: list[Klass]
+    active: bool
+
+
 @register.inclusion_tag("cbv/includes/nav.html")
 def nav(version, module=None, klass=None):
     other_versions = ProjectVersion.objects.filter(project=version.project).exclude(
@@ -64,10 +72,19 @@ def nav(version, module=None, klass=None):
             for other_version in other_versions
         ]
 
+    modules = [
+        ModuleData(
+            source_name=m.source_name,
+            short_name=m.short_name,
+            classes=list(m.klass_set.all()),
+            active=m == module,
+        )
+        for m in version.module_set.all()
+    ]
+
     return {
         "version": version,
         "other_versions": version_switcher,
-        "this_module": module,
         "this_klass": klass,
-        "modules": version.module_set.all(),
+        "modules": modules,
     }

--- a/cbv/templatetags/cbv_tags.py
+++ b/cbv/templatetags/cbv_tags.py
@@ -37,9 +37,15 @@ class OtherVersion:
 
 @attrs.frozen
 class ModuleData:
+    @attrs.frozen
+    class KlassData:
+        name: str
+        url: str
+        active: bool
+
     source_name: str
     short_name: str
-    classes: list[Klass]
+    classes: list[KlassData]
     active: bool
 
 
@@ -76,7 +82,14 @@ def nav(version, module=None, klass=None):
         ModuleData(
             source_name=m.source_name,
             short_name=m.short_name,
-            classes=list(m.klass_set.all()),
+            classes=[
+                ModuleData.KlassData(
+                    name=k.name,
+                    url=k.get_absolute_url(),
+                    active=k == klass,
+                )
+                for k in m.klass_set.all()
+            ],
             active=m == module,
         )
         for m in version.module_set.all()
@@ -85,6 +98,5 @@ def nav(version, module=None, klass=None):
     return {
         "version": version,
         "other_versions": version_switcher,
-        "this_klass": klass,
         "modules": modules,
     }

--- a/cbv/templatetags/cbv_tags.py
+++ b/cbv/templatetags/cbv_tags.py
@@ -35,11 +35,12 @@ def nav(version, module=None, klass=None):
     )
     context = {
         "version": version,
+        "other_versions": other_versions,
+        "this_module": module,
+        "this_klass": klass,
     }
     if module:
-        context["this_module"] = module
         if klass:
-            context["this_klass"] = klass
             other_versions_of_klass = Klass.objects.filter(
                 name=klass.name,
                 module__project_version__in=other_versions,
@@ -54,5 +55,4 @@ def nav(version, module=None, klass=None):
                     pass
                 else:
                     other_version.url = other_klass.get_absolute_url()
-    context["other_versions"] = other_versions
     return context

--- a/cbv/templatetags/cbv_tags.py
+++ b/cbv/templatetags/cbv_tags.py
@@ -92,7 +92,7 @@ def nav(version, module=None, klass=None):
             ],
             active=m == module,
         )
-        for m in version.module_set.all()
+        for m in version.module_set.prefetch_related("klass_set")
     ]
 
     return {

--- a/cbv/templatetags/cbv_tags.py
+++ b/cbv/templatetags/cbv_tags.py
@@ -39,8 +39,6 @@ def nav(version, module=None, klass=None):
         "this_module": module,
         "this_klass": klass,
     }
-    if not module:
-        return context
     if klass:
         other_versions_of_klass = Klass.objects.filter(
             name=klass.name,

--- a/cbv/templatetags/cbv_tags.py
+++ b/cbv/templatetags/cbv_tags.py
@@ -39,20 +39,21 @@ def nav(version, module=None, klass=None):
         "this_module": module,
         "this_klass": klass,
     }
-    if module:
-        if klass:
-            other_versions_of_klass = Klass.objects.filter(
-                name=klass.name,
-                module__project_version__in=other_versions,
-            )
-            other_versions_of_klass_dict = {
-                x.module.project_version: x for x in other_versions_of_klass
-            }
-            for other_version in other_versions:
-                try:
-                    other_klass = other_versions_of_klass_dict[other_version]
-                except KeyError:
-                    pass
-                else:
-                    other_version.url = other_klass.get_absolute_url()
+    if not module:
+        return context
+    if klass:
+        other_versions_of_klass = Klass.objects.filter(
+            name=klass.name,
+            module__project_version__in=other_versions,
+        )
+        other_versions_of_klass_dict = {
+            x.module.project_version: x for x in other_versions_of_klass
+        }
+        for other_version in other_versions:
+            try:
+                other_klass = other_versions_of_klass_dict[other_version]
+            except KeyError:
+                pass
+            else:
+                other_version.url = other_klass.get_absolute_url()
     return context

--- a/cbv/templatetags/cbv_tags.py
+++ b/cbv/templatetags/cbv_tags.py
@@ -69,4 +69,5 @@ def nav(version, module=None, klass=None):
         "other_versions": version_switcher,
         "this_module": module,
         "this_klass": klass,
+        "modules": version.module_set.all(),
     }

--- a/cbv/templatetags/cbv_tags.py
+++ b/cbv/templatetags/cbv_tags.py
@@ -33,12 +33,6 @@ def nav(version, module=None, klass=None):
     other_versions = ProjectVersion.objects.filter(project=version.project).exclude(
         pk=version.pk
     )
-    context = {
-        "version": version,
-        "other_versions": other_versions,
-        "this_module": module,
-        "this_klass": klass,
-    }
     if klass:
         other_versions_of_klass = Klass.objects.filter(
             name=klass.name,
@@ -54,4 +48,10 @@ def nav(version, module=None, klass=None):
                 pass
             else:
                 other_version.url = other_klass.get_absolute_url()
-    return context
+
+    return {
+        "version": version,
+        "other_versions": other_versions,
+        "this_module": module,
+        "this_klass": klass,
+    }

--- a/cbv/tests/test_page_snapshots.py
+++ b/cbv/tests/test_page_snapshots.py
@@ -12,17 +12,17 @@ from pytest_subtests import SubTests
 RENDERED_VIEWS = [
     (
         "homepage.html",
-        205,
+        197,
         reverse("home"),
     ),
     (
         "version-detail.html",
-        204,
+        196,
         reverse("version-detail", kwargs={"package": "django", "version": "4.0"}),
     ),
     (
         "module-detail.html",
-        27,
+        19,
         reverse(
             "module-detail",
             kwargs={
@@ -34,7 +34,7 @@ RENDERED_VIEWS = [
     ),
     (
         "klass-detail.html",
-        51,
+        43,
         reverse(
             "klass-detail",
             kwargs={
@@ -47,18 +47,18 @@ RENDERED_VIEWS = [
     ),
     (
         "klass-detail.html",
-        54,
+        46,
         reverse("klass-detail-shortcut", kwargs={"klass": "FormView"}),
     ),
     # Detail pages with wRonGLY CasEd arGuMEnTs
     (
         "fuzzy-version-detail.html",
-        204,
+        196,
         reverse("version-detail", kwargs={"package": "DJANGO", "version": "4.0"}),
     ),
     (
         "fuzzy-module-detail.html",
-        28,
+        20,
         reverse(
             "module-detail",
             kwargs={
@@ -70,7 +70,7 @@ RENDERED_VIEWS = [
     ),
     (
         "fuzzy-klass-detail.html",
-        51,
+        43,
         reverse(
             "klass-detail",
             kwargs={
@@ -83,7 +83,7 @@ RENDERED_VIEWS = [
     ),
     (
         "fuzzy-klass-detail.html",
-        54,
+        46,
         reverse("klass-detail-shortcut", kwargs={"klass": "fORMvIEW"}),
     ),
 ]

--- a/cbv/tests/test_page_snapshots.py
+++ b/cbv/tests/test_page_snapshots.py
@@ -12,17 +12,17 @@ from pytest_subtests import SubTests
 RENDERED_VIEWS = [
     (
         "homepage.html",
-        197,
+        190,
         reverse("home"),
     ),
     (
         "version-detail.html",
-        196,
+        189,
         reverse("version-detail", kwargs={"package": "django", "version": "4.0"}),
     ),
     (
         "module-detail.html",
-        19,
+        12,
         reverse(
             "module-detail",
             kwargs={
@@ -34,7 +34,7 @@ RENDERED_VIEWS = [
     ),
     (
         "klass-detail.html",
-        43,
+        36,
         reverse(
             "klass-detail",
             kwargs={
@@ -47,18 +47,18 @@ RENDERED_VIEWS = [
     ),
     (
         "klass-detail.html",
-        46,
+        39,
         reverse("klass-detail-shortcut", kwargs={"klass": "FormView"}),
     ),
     # Detail pages with wRonGLY CasEd arGuMEnTs
     (
         "fuzzy-version-detail.html",
-        196,
+        189,
         reverse("version-detail", kwargs={"package": "DJANGO", "version": "4.0"}),
     ),
     (
         "fuzzy-module-detail.html",
-        20,
+        13,
         reverse(
             "module-detail",
             kwargs={
@@ -70,7 +70,7 @@ RENDERED_VIEWS = [
     ),
     (
         "fuzzy-klass-detail.html",
-        43,
+        36,
         reverse(
             "klass-detail",
             kwargs={
@@ -83,7 +83,7 @@ RENDERED_VIEWS = [
     ),
     (
         "fuzzy-klass-detail.html",
-        46,
+        39,
         reverse("klass-detail-shortcut", kwargs={"klass": "fORMvIEW"}),
     ),
 ]

--- a/inspector/settings.py
+++ b/inspector/settings.py
@@ -19,6 +19,8 @@ INSTALLED_APPS = [
     # Third Party Apps
     "django_extensions",
     "django_pygmy",
+    "sans_db",
+    # Django
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ django~=3.1.14
 dj-database-url
 django-extensions
 django-pygmy
+django-sans-db
 factory_boy
 gunicorn
 mypy

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-attrs
+attrs>=21.4.0
 blessings
 coverage[toml]
 django~=3.1.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,8 @@ django-extensions==3.1.3
     # via -r requirements.in
 django-pygmy==0.1.5
     # via -r requirements.in
+django-sans-db==1.1.0
+    # via -r requirements.in
 docutils==0.17.1
     # via sphinx
 factory-boy==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.4.1
     # via django
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   -r requirements.in
     #   pytest


### PR DESCRIPTION
We shouldn't be making queries in templates, but unfortunately, that happens a lot in this project.

This removes the database queries from the nav template, and moves them into the nav templatetag code. I'm not in love with the code that's come out of this, but it's a step in the right direction.

As a bonus, we've shaved a few queries out of what is required when rendering the page.

I've shamelessly added my new library [`django-sans-db`](https://github.com/meshy/django-sans-db), and have set it up to prevent regressions in this template.

