### PR TITLE
Add explicit ordering to navigation elements

### DIFF
--- a/cbv/templatetags/cbv_tags.py
+++ b/cbv/templatetags/cbv_tags.py
@@ -98,7 +98,7 @@ def nav(version, module=None, klass=None):
 
     modules = [
         ModuleData.from_module(module=m, active_module=module, active_klass=klass)
-        for m in version.module_set.prefetch_related("klass_set")
+        for m in version.module_set.prefetch_related("klass_set").order_by("name")
     ]
 
     return {

--- a/cbv/tests/_page_snapshots/fuzzy-klass-detail.html
+++ b/cbv/tests/_page_snapshots/fuzzy-klass-detail.html
@@ -37,7 +37,9 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    <li li="version-4.0" class="dropdown">
+    
+
+<li li="version-4.0" class="dropdown">
     
         <a href="#version-4.0" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -51,6 +53,89 @@
         </ul>
     
 </li>
+
+    
+        <li class="divider-vertical"></li>
+        <li><a href="#">Auth</a></li>
+    
+    
+        <li id="module-mixins" class="dropdown">
+            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
+                Mixins <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
+
+    
+    
+        <li id="module-views" class="dropdown">
+            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
+                Views <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
 
     
         <li class="divider-vertical"></li>
@@ -308,88 +393,6 @@
         </li>
     
 
-    
-        <li class="divider-vertical"></li>
-        <li><a href="#">Auth</a></li>
-    
-    
-        <li id="module-views" class="dropdown">
-            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
-                Views <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
-
-    
-    
-        <li id="module-mixins" class="dropdown">
-            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
-                Mixins <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
 
 
 

--- a/cbv/tests/_page_snapshots/fuzzy-module-detail.html
+++ b/cbv/tests/_page_snapshots/fuzzy-module-detail.html
@@ -32,7 +32,9 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    <li li="version-4.0" class="dropdown">
+    
+
+<li li="version-4.0" class="dropdown">
     
         <a href="#version-4.0" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -46,6 +48,89 @@
         </ul>
     
 </li>
+
+    
+        <li class="divider-vertical"></li>
+        <li><a href="#">Auth</a></li>
+    
+    
+        <li id="module-mixins" class="dropdown">
+            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
+                Mixins <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
+
+    
+    
+        <li id="module-views" class="dropdown">
+            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
+                Views <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
 
     
         <li class="divider-vertical"></li>
@@ -303,88 +388,6 @@
         </li>
     
 
-    
-        <li class="divider-vertical"></li>
-        <li><a href="#">Auth</a></li>
-    
-    
-        <li id="module-views" class="dropdown">
-            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
-                Views <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
-
-    
-    
-        <li id="module-mixins" class="dropdown">
-            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
-                Mixins <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
 
 
 

--- a/cbv/tests/_page_snapshots/fuzzy-version-detail.html
+++ b/cbv/tests/_page_snapshots/fuzzy-version-detail.html
@@ -27,7 +27,9 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    <li li="version-4.0" class="dropdown">
+    
+
+<li li="version-4.0" class="dropdown">
     
         <a href="#version-4.0" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -41,6 +43,89 @@
         </ul>
     
 </li>
+
+    
+        <li class="divider-vertical"></li>
+        <li><a href="#">Auth</a></li>
+    
+    
+        <li id="module-mixins" class="dropdown">
+            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
+                Mixins <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
+
+    
+    
+        <li id="module-views" class="dropdown">
+            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
+                Views <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
 
     
         <li class="divider-vertical"></li>
@@ -298,88 +383,6 @@
         </li>
     
 
-    
-        <li class="divider-vertical"></li>
-        <li><a href="#">Auth</a></li>
-    
-    
-        <li id="module-views" class="dropdown">
-            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
-                Views <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
-
-    
-    
-        <li id="module-mixins" class="dropdown">
-            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
-                Mixins <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
 
 
 

--- a/cbv/tests/_page_snapshots/homepage.html
+++ b/cbv/tests/_page_snapshots/homepage.html
@@ -25,7 +25,9 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    <li li="version-4.0" class="dropdown">
+    
+
+<li li="version-4.0" class="dropdown">
     
         <a href="#version-4.0" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -39,6 +41,89 @@
         </ul>
     
 </li>
+
+    
+        <li class="divider-vertical"></li>
+        <li><a href="#">Auth</a></li>
+    
+    
+        <li id="module-mixins" class="dropdown">
+            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
+                Mixins <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
+
+    
+    
+        <li id="module-views" class="dropdown">
+            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
+                Views <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
 
     
         <li class="divider-vertical"></li>
@@ -296,88 +381,6 @@
         </li>
     
 
-    
-        <li class="divider-vertical"></li>
-        <li><a href="#">Auth</a></li>
-    
-    
-        <li id="module-views" class="dropdown">
-            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
-                Views <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
-
-    
-    
-        <li id="module-mixins" class="dropdown">
-            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
-                Mixins <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
 
 
 

--- a/cbv/tests/_page_snapshots/klass-detail.html
+++ b/cbv/tests/_page_snapshots/klass-detail.html
@@ -37,7 +37,9 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    <li li="version-4.0" class="dropdown">
+    
+
+<li li="version-4.0" class="dropdown">
     
         <a href="#version-4.0" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -51,6 +53,89 @@
         </ul>
     
 </li>
+
+    
+        <li class="divider-vertical"></li>
+        <li><a href="#">Auth</a></li>
+    
+    
+        <li id="module-mixins" class="dropdown">
+            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
+                Mixins <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
+
+    
+    
+        <li id="module-views" class="dropdown">
+            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
+                Views <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
 
     
         <li class="divider-vertical"></li>
@@ -308,88 +393,6 @@
         </li>
     
 
-    
-        <li class="divider-vertical"></li>
-        <li><a href="#">Auth</a></li>
-    
-    
-        <li id="module-views" class="dropdown">
-            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
-                Views <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
-
-    
-    
-        <li id="module-mixins" class="dropdown">
-            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
-                Mixins <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
 
 
 

--- a/cbv/tests/_page_snapshots/module-detail.html
+++ b/cbv/tests/_page_snapshots/module-detail.html
@@ -27,7 +27,9 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    <li li="version-4.0" class="dropdown">
+    
+
+<li li="version-4.0" class="dropdown">
     
         <a href="#version-4.0" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -41,6 +43,89 @@
         </ul>
     
 </li>
+
+    
+        <li class="divider-vertical"></li>
+        <li><a href="#">Auth</a></li>
+    
+    
+        <li id="module-mixins" class="dropdown">
+            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
+                Mixins <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
+
+    
+    
+        <li id="module-views" class="dropdown">
+            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
+                Views <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
 
     
         <li class="divider-vertical"></li>
@@ -298,88 +383,6 @@
         </li>
     
 
-    
-        <li class="divider-vertical"></li>
-        <li><a href="#">Auth</a></li>
-    
-    
-        <li id="module-views" class="dropdown">
-            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
-                Views <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
-
-    
-    
-        <li id="module-mixins" class="dropdown">
-            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
-                Mixins <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
 
 
 

--- a/cbv/tests/_page_snapshots/version-detail.html
+++ b/cbv/tests/_page_snapshots/version-detail.html
@@ -27,7 +27,9 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    <li li="version-4.0" class="dropdown">
+    
+
+<li li="version-4.0" class="dropdown">
     
         <a href="#version-4.0" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -41,6 +43,89 @@
         </ul>
     
 </li>
+
+    
+        <li class="divider-vertical"></li>
+        <li><a href="#">Auth</a></li>
+    
+    
+        <li id="module-mixins" class="dropdown">
+            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
+                Mixins <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
+
+    
+    
+        <li id="module-views" class="dropdown">
+            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
+                Views <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
+                    </li>
+                
+                    <li >
+                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
+                    </li>
+                
+            </ul>
+        </li>
+    
 
     
         <li class="divider-vertical"></li>
@@ -298,88 +383,6 @@
         </li>
     
 
-    
-        <li class="divider-vertical"></li>
-        <li><a href="#">Auth</a></li>
-    
-    
-        <li id="module-views" class="dropdown">
-            <a href="#module-views" class="dropdown-toggle" data-toggle="dropdown">
-                Views <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/LogoutView/">LogoutView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeDoneView/">PasswordChangeDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordContextMixin/">PasswordContextMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetCompleteView/">PasswordResetCompleteView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetDoneView/">PasswordResetDoneView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.views/SuccessURLAllowedHostsMixin/">SuccessURLAllowedHostsMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
-
-    
-    
-        <li id="module-mixins" class="dropdown">
-            <a href="#module-mixins" class="dropdown-toggle" data-toggle="dropdown">
-                Mixins <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/AccessMixin/">AccessMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/LoginRequiredMixin/">LoginRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/PermissionRequiredMixin/">PermissionRequiredMixin</a>
-                    </li>
-                
-                    <li >
-                        <a href="/projects/Django/4.0/django.contrib.auth.mixins/UserPassesTestMixin/">UserPassesTestMixin</a>
-                    </li>
-                
-            </ul>
-        </li>
-    
 
 
 


### PR DESCRIPTION
This means "Auth" now comes before "Generic" the top bar navigation.

Before:
![Screenshot from 2022-08-14 21-15-59](https://user-images.githubusercontent.com/767671/184553407-ca3d373c-c53d-45b2-9dc2-c38c8ec3c8e1.png)

After:
![Screenshot from 2022-08-14 21-16-08](https://user-images.githubusercontent.com/767671/184553408-f3b4e211-6e4b-45cd-b66b-ca0a91e123a6.png)

This means that the order is no longer dependent on the order that the items were inserted into the database.