### PR TITLE
Modern paths

### DIFF
--- a/cbv/shortcut_urls.py
+++ b/cbv/shortcut_urls.py
@@ -1,11 +1,11 @@
-from django.urls import re_path
+from django.urls import path
 
 from cbv import views
 
 
 urlpatterns = [
-    re_path(
-        r"(?P<klass>[a-zA-Z_-]+)/$",
+    path(
+        "<str:klass>/",
         views.LatestKlassDetailView.as_view(),
         name="klass-detail-shortcut",
     ),

--- a/cbv/urls.py
+++ b/cbv/urls.py
@@ -21,54 +21,77 @@ from cbv import views
 
 urlpatterns = [
     path("", RedirectView.as_view(url=reverse_lazy("home"))),
-    path("<slug:package>/", include([
-        path(
-            "",
-            views.RedirectToLatestVersionView.as_view(),
-            {"url_name": "version-detail"},
+    path(
+        "<slug:package>/",
+        include(
+            [
+                path(
+                    "",
+                    views.RedirectToLatestVersionView.as_view(),
+                    {"url_name": "version-detail"},
+                ),
+                path(
+                    "latest/",
+                    include(
+                        [
+                            path(
+                                "",
+                                views.RedirectToLatestVersionView.as_view(),
+                                {"url_name": "version-detail"},
+                                name="latest-version-detail",
+                            ),
+                            path(
+                                "<str:module>/",
+                                include(
+                                    [
+                                        path(
+                                            "",
+                                            views.RedirectToLatestVersionView.as_view(),
+                                            {"url_name": "module-detail"},
+                                            name="latest-module-detail",
+                                        ),
+                                        path(
+                                            "<str:klass>/",
+                                            views.RedirectToLatestVersionView.as_view(),
+                                            {"url_name": "klass-detail"},
+                                            name="latest-klass-detail",
+                                        ),
+                                    ]
+                                ),
+                            ),
+                        ]
+                    ),
+                ),
+                path(
+                    "<str:version>/",
+                    include(
+                        [
+                            path(
+                                "",
+                                views.VersionDetailView.as_view(),
+                                name="version-detail",
+                            ),
+                            path(
+                                "<str:module>/",
+                                include(
+                                    [
+                                        path(
+                                            "",
+                                            views.ModuleDetailView.as_view(),
+                                            name="module-detail",
+                                        ),
+                                        path(
+                                            "<str:klass>/",
+                                            views.KlassDetailView.as_view(),
+                                            name="klass-detail",
+                                        ),
+                                    ]
+                                ),
+                            ),
+                        ]
+                    ),
+                ),
+            ]
         ),
-        path(
-            "latest/", include([
-            path(
-                "",
-                views.RedirectToLatestVersionView.as_view(),
-                {"url_name": "version-detail"},
-                name="latest-version-detail",
-            ),
-            path("<str:module>/", include([
-                path(
-                    "",
-                    views.RedirectToLatestVersionView.as_view(),
-                    {"url_name": "module-detail"},
-                    name="latest-module-detail"
-                ),
-                path(
-                    "<str:klass>/",
-                    views.RedirectToLatestVersionView.as_view(),
-                    {"url_name": "klass-detail"},
-                    name="latest-klass-detail",
-                )
-            ])),
-        ])),
-        path(
-            "<str:version>/", include([
-            path(
-                "",
-                views.VersionDetailView.as_view(),
-                name="version-detail",
-            ),
-            path("<str:module>/", include([
-                path(
-                    "",
-                    views.ModuleDetailView.as_view(),
-                    name="module-detail"
-                ),
-                path(
-                    "<str:klass>/",
-                    views.KlassDetailView.as_view(),
-                    name="klass-detail",
-                )
-            ])),
-        ]))
-    ]))
+    ),
 ]

--- a/cbv/urls.py
+++ b/cbv/urls.py
@@ -13,7 +13,7 @@ django/1.41a/core/DjangoRuntimeWarning
 
 """
 
-from django.urls import path, re_path, reverse_lazy
+from django.urls import include, path, reverse_lazy
 from django.views.generic import RedirectView
 
 from cbv import views
@@ -21,42 +21,54 @@ from cbv import views
 
 urlpatterns = [
     path("", RedirectView.as_view(url=reverse_lazy("home"))),
-    re_path(
-        r"^(?P<package>[\w-]+)/$",
-        views.RedirectToLatestVersionView.as_view(),
-        {"url_name": "version-detail"},
-    ),
-    re_path(
-        r"^(?P<package>[\w-]+)/latest/$",
-        views.RedirectToLatestVersionView.as_view(),
-        {"url_name": "version-detail"},
-        name="latest-version-detail",
-    ),
-    re_path(
-        r"^(?P<package>[\w-]+)/(?P<version>[^/]+)/$",
-        views.VersionDetailView.as_view(),
-        name="version-detail",
-    ),
-    re_path(
-        r"^(?P<package>[\w-]+)/latest/(?P<module>[\w\.]+)/$",
-        views.RedirectToLatestVersionView.as_view(),
-        {"url_name": "module-detail"},
-        name="latest-module-detail",
-    ),
-    re_path(
-        r"^(?P<package>[\w-]+)/(?P<version>[^/]+)/(?P<module>[\w\.]+)/$",
-        views.ModuleDetailView.as_view(),
-        name="module-detail",
-    ),
-    re_path(
-        r"^(?P<package>[\w-]+)/latest/(?P<module>[\w\.]+)/(?P<klass>[\w]+)/$",
-        views.RedirectToLatestVersionView.as_view(),
-        {"url_name": "klass-detail"},
-        name="latest-klass-detail",
-    ),
-    re_path(
-        r"^(?P<package>[\w-]+)/(?P<version>[^/]+)/(?P<module>[\w\.]+)/(?P<klass>[\w]+)/$",
-        views.KlassDetailView.as_view(),
-        name="klass-detail",
-    ),
+    path("<slug:package>/", include([
+        path(
+            "",
+            views.RedirectToLatestVersionView.as_view(),
+            {"url_name": "version-detail"},
+        ),
+        path(
+            "latest/", include([
+            path(
+                "",
+                views.RedirectToLatestVersionView.as_view(),
+                {"url_name": "version-detail"},
+                name="latest-version-detail",
+            ),
+            path("<str:module>/", include([
+                path(
+                    "",
+                    views.RedirectToLatestVersionView.as_view(),
+                    {"url_name": "module-detail"},
+                    name="latest-module-detail"
+                ),
+                path(
+                    "<str:klass>/",
+                    views.RedirectToLatestVersionView.as_view(),
+                    {"url_name": "klass-detail"},
+                    name="latest-klass-detail",
+                )
+            ])),
+        ])),
+        path(
+            "<str:version>/", include([
+            path(
+                "",
+                views.VersionDetailView.as_view(),
+                name="version-detail",
+            ),
+            path("<str:module>/", include([
+                path(
+                    "",
+                    views.ModuleDetailView.as_view(),
+                    name="module-detail"
+                ),
+                path(
+                    "<str:klass>/",
+                    views.KlassDetailView.as_view(),
+                    name="klass-detail",
+                )
+            ])),
+        ]))
+    ]))
 ]

--- a/cbv/urls.py
+++ b/cbv/urls.py
@@ -12,7 +12,7 @@ django/1.41a/core
 django/1.41a/core/DjangoRuntimeWarning
 """
 
-from django.urls import include, path, reverse_lazy
+from django.urls import path, reverse_lazy
 from django.views.generic import RedirectView
 
 from cbv import views
@@ -22,75 +22,40 @@ urlpatterns = [
     path("", RedirectView.as_view(url=reverse_lazy("home"))),
     path(
         "<slug:package>/",
-        include(
-            [
-                path(
-                    "",
-                    views.RedirectToLatestVersionView.as_view(),
-                    {"url_name": "version-detail"},
-                ),
-                path(
-                    "latest/",
-                    include(
-                        [
-                            path(
-                                "",
-                                views.RedirectToLatestVersionView.as_view(),
-                                {"url_name": "version-detail"},
-                                name="latest-version-detail",
-                            ),
-                            path(
-                                "<str:module>/",
-                                include(
-                                    [
-                                        path(
-                                            "",
-                                            views.RedirectToLatestVersionView.as_view(),
-                                            {"url_name": "module-detail"},
-                                            name="latest-module-detail",
-                                        ),
-                                        path(
-                                            "<str:klass>/",
-                                            views.RedirectToLatestVersionView.as_view(),
-                                            {"url_name": "klass-detail"},
-                                            name="latest-klass-detail",
-                                        ),
-                                    ]
-                                ),
-                            ),
-                        ]
-                    ),
-                ),
-                path(
-                    "<str:version>/",
-                    include(
-                        [
-                            path(
-                                "",
-                                views.VersionDetailView.as_view(),
-                                name="version-detail",
-                            ),
-                            path(
-                                "<str:module>/",
-                                include(
-                                    [
-                                        path(
-                                            "",
-                                            views.ModuleDetailView.as_view(),
-                                            name="module-detail",
-                                        ),
-                                        path(
-                                            "<str:klass>/",
-                                            views.KlassDetailView.as_view(),
-                                            name="klass-detail",
-                                        ),
-                                    ]
-                                ),
-                            ),
-                        ]
-                    ),
-                ),
-            ]
-        ),
+        views.RedirectToLatestVersionView.as_view(),
+        {"url_name": "version-detail"},
+    ),
+    path(
+        "<slug:package>/latest/",
+        views.RedirectToLatestVersionView.as_view(),
+        {"url_name": "version-detail"},
+        name="latest-version-detail",
+    ),
+    path(
+        "<slug:package>/<str:version>/",
+        views.VersionDetailView.as_view(),
+        name="version-detail",
+    ),
+    path(
+        "<slug:package>/latest/<str:module>/",
+        views.RedirectToLatestVersionView.as_view(),
+        {"url_name": "module-detail"},
+        name="latest-module-detail",
+    ),
+    path(
+        "<slug:package>/<str:version>/<str:module>/",
+        views.ModuleDetailView.as_view(),
+        name="module-detail",
+    ),
+    path(
+        "<slug:package>/latest/<str:module>/<str:klass>/",
+        views.RedirectToLatestVersionView.as_view(),
+        {"url_name": "klass-detail"},
+        name="latest-klass-detail",
+    ),
+    path(
+        "<slug:package>/<str:version>/<str:module>/<str:klass>/",
+        views.KlassDetailView.as_view(),
+        name="klass-detail",
     ),
 ]

--- a/cbv/urls.py
+++ b/cbv/urls.py
@@ -10,7 +10,6 @@ django
 django/1.41a
 django/1.41a/core
 django/1.41a/core/DjangoRuntimeWarning
-
 """
 
 from django.urls import include, path, reverse_lazy

--- a/inspector/urls.py
+++ b/inspector/urls.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.conf.urls.static import static
-from django.urls import include, path, re_path
+from django.urls import include, path
 from django.views.generic import TemplateView
 
 from cbv.views import HomeView, Sitemap
@@ -9,7 +9,7 @@ from cbv.views import HomeView, Sitemap
 urlpatterns = [
     path("", HomeView.as_view(), name="home"),
     path("projects/", include("cbv.urls")),
-    re_path(r"^sitemap\.xml$", Sitemap.as_view(), name="sitemap"),
+    path("sitemap.xml", Sitemap.as_view(), name="sitemap"),
     path("", include("cbv.shortcut_urls"), {"package": "Django"}),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 


### PR DESCRIPTION
Use `path` instead of `re_path`, and work with a cascade of path patterns to avoid code duplication for the parameters.