### PR TITLE
Freeze sitemap

### DIFF
--- a/cbv/templates/sitemap.xml
+++ b/cbv/templates/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% spaceless %}
+{% for url in urlset %}
+  <url>
+    <loc>{{ url.location }}</loc>
+    {% if url.lastmod %}<lastmod>{{ url.lastmod|date:"Y-m-d" }}</lastmod>{% endif %}
+    {% if url.changefreq %}<changefreq>{{ url.changefreq }}</changefreq>{% endif %}
+    {% if url.priority %}<priority>{{ url.priority }}</priority>{% endif %}
+   </url>
+{% endfor %}
+{% endspaceless %}
+</urlset>

--- a/cbv/templates/sitemap.xml
+++ b/cbv/templates/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 {% spaceless %}
 {% for url in urlset %}
   <url>

--- a/cbv/templates/sitemap.xml
+++ b/cbv/templates/sitemap.xml
@@ -4,8 +4,6 @@
 {% for url in urlset %}
   <url>
     <loc>{{ url.location }}</loc>
-    {% if url.lastmod %}<lastmod>{{ url.lastmod|date:"Y-m-d" }}</lastmod>{% endif %}
-    {% if url.changefreq %}<changefreq>{{ url.changefreq }}</changefreq>{% endif %}
     {% if url.priority %}<priority>{{ url.priority }}</priority>{% endif %}
    </url>
 {% endfor %}

--- a/cbv/tests/files/empty-sitemap.xml
+++ b/cbv/tests/files/empty-sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 <url><loc>/</loc><priority>1.0</priority></url>
 </urlset>

--- a/cbv/tests/files/populated-sitemap.xml
+++ b/cbv/tests/files/populated-sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 <url><loc>/</loc><priority>1.0</priority></url><url><loc>/projects/Django/42.0/module.name/Klass/</loc><priority>0.9</priority></url><url><loc>/projects/Django/41.0/module.name/Klass/</loc><priority>0.5</priority></url>
 </urlset>


### PR DESCRIPTION
Django updates the sitemap template in later versions. To prevent changes when upgrading Django, this freezes the template.

We incorporate the [only important change from the parent template](https://github.com/django/django/commit/50e1ccbbea4c6f8e14a186149dd757483f0f0da5).

This is spun out of #175.