### PR TITLE
Remove unused apps, middleware, and context processors

### DIFF
--- a/inspector/settings.py
+++ b/inspector/settings.py
@@ -21,22 +21,13 @@ INSTALLED_APPS = [
     "django_pygmy",
     "sans_db",
     # Django
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "django.contrib.sessions",
-    "django.contrib.messages",
-    "django.contrib.sitemaps",
     "django.contrib.staticfiles",
 ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
@@ -45,37 +36,13 @@ ROOT_URLCONF = "inspector.urls"
 TEMPLATES = [
     {
         "BACKEND": "sans_db.template_backends.django_sans_db.DjangoTemplatesSansDB",
-        "DIRS": [],
         "APP_DIRS": True,
-        "OPTIONS": {
-            "context_processors": [
-                "django.template.context_processors.debug",
-                "django.template.context_processors.request",
-                "django.contrib.auth.context_processors.auth",
-                "django.contrib.messages.context_processors.messages",
-            ],
-        },
     },
 ]
 
 WSGI_APPLICATION = "inspector.wsgi.application"
 
 DATABASES = {"default": dj_database_url.config(default="postgres://localhost/ccbv")}
-
-AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
-    },
-]
 
 LANGUAGE_CODE = "en"
 TIME_ZONE = "Europe/London"


### PR DESCRIPTION
We don't use any of these apps, middleware, or context processors. They mostly relate to users and auth, which haven't been needed by the website for a long time. We don't need CSRF protection, because no-one can submit data to the website -- everything is GET requests.

This leaves us with the following models:

![image](https://user-images.githubusercontent.com/767671/198837053-359c1b11-66ba-40d2-88d0-bbb30071cd53.png)
