### PR TITLE
Remove postgresql client install in CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -25,11 +25,6 @@ jobs:
       - name: Clone code
         uses: actions/checkout@v3
 
-      - name: Install PostgreSQL client
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes postgresql-client
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
This was likely necessary in an early version of GHA, but is no longer necessary so we can save a little time on test runs.

Fixes #194 