### PR TITLE
Add coverage measurement context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ tests/test.zip
 *.sqlite
 *.db
 staticfiles
+.coverage
+.env
+.pytest_cache
+htmlcov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,14 @@ skip_glob = [".direnv", ".env", ".venv", "venv"]
 
 [tool.coverage.run]
 branch = true
+dynamic_context = "test_function"
 
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
+
+[tool.coverage.html]
+show_contexts = true
 
 [tool.mypy]
 check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
-[tool.black]
-extend-exclude = '/(\.direnv|\.env|\.venv|venv)/'
-
 [tool.isort]
 default_section = "THIRDPARTY"
 lines_after_imports = 2


### PR DESCRIPTION
This configures [Coverage's dynamic measurement contexts](https://coverage.readthedocs.io/en/6.4.4/contexts.html#dynamic-contexts) to help us find which tests executed a given line.

While adding that I also updated the black exclude config to ignore the output of coverage, and discovered the defaults are quite extensive (`/(\.direnv|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|venv|\.svn|_build|buck-out|build|dist|__pypackages__)/` according to `black --help`!) allowing us to drop a couple of directories.

Fixes #195 