### PR TITLE
Use sqlite database in production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ mypy:
 build:
 	pip install -r requirements.txt
 	python manage.py collectstatic --no-input
+	rm --force ccbv.sqlite
+	DATABASE_URL=sqlite:///ccbv.sqlite python manage.py migrate
+	DATABASE_URL=sqlite:///ccbv.sqlite python manage.py loaddata $(shell find cbv/fixtures -name '*.json' | xargs)
 
 run-prod:
-	gunicorn core.wsgi --log-file -
+	DATABASE_URL=sqlite:///ccbv.sqlite gunicorn core.wsgi --log-file -


### PR DESCRIPTION
Before now, we've been using a postgres database to store the data in production. It's not worth the maintenance cost.

This changes the start-up script we use in production to create and populate an SQLite file before we start the server process.

We probably don't need to take the step of removing the sqlite file, but I'm not sure if it might already exist from previous builds in prod.