### PR TITLE
Don't count protocols in test coverage

### DIFF
--- a/cbv/importer/importers.py
+++ b/cbv/importer/importers.py
@@ -27,7 +27,7 @@ BANNED_ATTR_NAMES = (
 )
 
 
-class CodeImporter(Protocol):
+class CodeImporter(Protocol):  # nocoverage: protocol
     def generate_code_data(self) -> Iterator[CodeElement]: ...
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ dynamic_context = "test_function"
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
+exclude_lines = [
+    # Protocol classes are abstract, and don't need coverage.
+    "nocoverage: protocol",
+]
 
 [tool.coverage.html]
 show_contexts = true

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,7 +9,7 @@ from django.urls import reverse_lazy
 from .factories import KlassFactory, ProjectVersionFactory
 
 
-class AssertNumQueriesFixture(Protocol):
+class AssertNumQueriesFixture(Protocol):  # nocoverage: protocol
     def __call__(self, num: int, exact: bool = True) -> CaptureQueriesContext: ...
 
 


### PR DESCRIPTION
Protocols are not directly executed, so it doesn't make sense to count them in code-coverage.