### PR TITLE
Update precommit linters' versions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,4 +7,6 @@ ignore =
     E501
     # line break before binary operator (conflicts with Black)
     W503
+    # multiple statements on one line (conflicts with Black)
+    E704
 max_line_length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,28 +3,28 @@ default_language_version:
      python: python3.10
 repos:
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.13.0
+    rev: 1.17.0
     hooks:
     - id: django-upgrade
       args: [--target-version, "3.1"]
 
   - repo: https://github.com/ambv/black
-    rev: 23.3.0
+    rev: 24.4.2
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.15.2
     hooks:
       - id: pyupgrade
         args:

--- a/cbv/importer/dataclasses.py
+++ b/cbv/importer/dataclasses.py
@@ -1,4 +1,5 @@
 """Data classes used in the process of importing code."""
+
 import abc
 
 import attr

--- a/cbv/importer/importers.py
+++ b/cbv/importer/importers.py
@@ -28,8 +28,7 @@ BANNED_ATTR_NAMES = (
 
 
 class CodeImporter(Protocol):
-    def generate_code_data(self) -> Iterator[CodeElement]:
-        ...
+    def generate_code_data(self) -> Iterator[CodeElement]: ...
 
 
 @attr.frozen

--- a/cbv/models.py
+++ b/cbv/models.py
@@ -312,11 +312,11 @@ class Klass(models.Model):
                     parent=ancestor.name,
                     child=self.name,
                     parent_col="white" if ancestor.is_secondary() else "lightblue",
-                    child_col="green"
-                    if first
-                    else "white"
-                    if self.is_secondary()
-                    else "lightblue",
+                    child_col=(
+                        "green"
+                        if first
+                        else "white" if self.is_secondary() else "lightblue"
+                    ),
                 )
             )
             yuml_data += ancestor.basic_yuml_data()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -10,8 +10,7 @@ from .factories import KlassFactory, ProjectVersionFactory
 
 
 class AssertNumQueriesFixture(Protocol):
-    def __call__(self, num: int, exact: bool = True) -> CaptureQueriesContext:
-        ...
+    def __call__(self, num: int, exact: bool = True) -> CaptureQueriesContext: ...
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This updates the versions in the precommit config, and applies them to our files.

Flake8 is told to ignore E704, which would otherwise conflict with the new Black formatting style.

I was urged to do this because [installing the old version of isort was failing](https://github.com/PyCQA/isort/issues/2228).

There's an open question about which of these tools we should continue to use, but that's a question for a different time.