### PR TITLE
Remove __str__ methods from models

### DIFF
--- a/cbv/models.py
+++ b/cbv/models.py
@@ -152,9 +152,6 @@ class Klass(models.Model):
         unique_together = ("module", "name")
         ordering = ("module__name", "name")
 
-    def __str__(self) -> str:
-        return self.name
-
     def natural_key(self) -> tuple[str, str, str, str]:
         return (self.name,) + self.module.natural_key()
 

--- a/cbv/models.py
+++ b/cbv/models.py
@@ -29,9 +29,6 @@ class ProjectVersion(models.Model):
         )
         ordering = ("-sortable_version_number",)
 
-    def __str__(self) -> str:
-        return f"Django {self.version_number}"
-
     def save(self, *args: object, **kwargs: object) -> None:
         if not self.sortable_version_number:
             self.sortable_version_number = self.generate_sortable_version_number()

--- a/cbv/models.py
+++ b/cbv/models.py
@@ -74,9 +74,6 @@ class Module(models.Model):
     class Meta:
         unique_together = ("project_version", "name")
 
-    def __str__(self) -> str:
-        return self.name
-
     def short_name(self) -> str:
         return self.name.split(".")[-1]
 

--- a/cbv/models.py
+++ b/cbv/models.py
@@ -334,9 +334,6 @@ class Inheritance(models.Model):
         ordering = ("order",)
         unique_together = ("child", "order")
 
-    def __str__(self) -> str:
-        return f"{self.parent} <- {self.child} ({self.order})"
-
 
 class KlassAttribute(models.Model):
     """Represents an attribute on a Klass"""
@@ -350,9 +347,6 @@ class KlassAttribute(models.Model):
         ordering = ("name",)
         unique_together = ("klass", "name")
 
-    def __str__(self) -> str:
-        return f"{self.name} = {self.value}"
-
 
 class Method(models.Model):
     """Represents a method on a Klass"""
@@ -363,9 +357,6 @@ class Method(models.Model):
     code = models.TextField()
     kwargs = models.CharField(max_length=200)
     line_number = models.IntegerField()
-
-    def __str__(self) -> str:
-        return self.name
 
     class Meta:
         ordering = ("name",)

--- a/cbv/queries.py
+++ b/cbv/queries.py
@@ -7,6 +7,7 @@ from cbv import models
 class VersionSwitcher:
     version_name: str
     other_versions: list["OtherVersion"]
+    project_name: str = "Django"
 
     @attrs.frozen
     class OtherVersion:
@@ -77,18 +78,21 @@ class NavBuilder:
                     url = other_klass.get_absolute_url()
 
                 versions.append(
-                    VersionSwitcher.OtherVersion(name=str(other_version), url=url)
+                    VersionSwitcher.OtherVersion(
+                        name=other_version.version_number, url=url
+                    )
                 )
         else:
             versions = [
                 VersionSwitcher.OtherVersion(
-                    name=str(other_version), url=other_version.get_absolute_url()
+                    name=other_version.version_number,
+                    url=other_version.get_absolute_url(),
                 )
                 for other_version in other_versions
             ]
 
         version_switcher = VersionSwitcher(
-            version_name=str(project_version),
+            version_name=project_version.version_number,
             other_versions=versions,
         )
         return version_switcher

--- a/cbv/templates/cbv/_klass_list.html
+++ b/cbv/templates/cbv/_klass_list.html
@@ -9,7 +9,7 @@
     {% endifchanged %}
     <li class="{% if obj.is_secondary %}secondary{% else %}primary{% endif %}">
         <a href="{{ obj.get_absolute_url }}" {% if obj.docstring %}class="klass-tooltip" data-original-title="{{ obj.docstring }}" data-placement="bottom"{% endif %}>
-            {{ obj }}
+            {{ obj.name }}
         </a>
     </li>
 {% endfor %}

--- a/cbv/templates/cbv/_klass_list.html
+++ b/cbv/templates/cbv/_klass_list.html
@@ -1,6 +1,6 @@
 <div class="span{{ column_width }}">
 {% for obj in object_list %}
-    {% ifchanged obj.module %}
+    {% ifchanged obj.module.name %}
         {% if not forloop.first %}</ul></div>{% endif %}
         {% if obj.module.short_name == 'detail'%}</div><div class="span{{ column_width }}">{% endif %}
         <div class="well skinny klass-list">

--- a/cbv/templates/cbv/includes/nav.html
+++ b/cbv/templates/cbv/includes/nav.html
@@ -1,14 +1,14 @@
 <li class="dropdown">
     {% if not version_switcher.other_versions %}
-        <a href="#">{{ version_switcher.version_name }}</a>
+        <a href="#">{{ version_switcher.project_name }} {{ version_switcher.version_name }}</a>
     {% else %}
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-            {{ version_switcher.version_name }} <b class="caret"></b>
+            {{ version_switcher.project_name }} {{ version_switcher.version_name }} <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
             {% for v in version_switcher.other_versions %}
                 <li>
-                    <a href="{{ v.url }}">{{ v.name }}</a>
+                    <a href="{{ v.url }}">{{ version_switcher.project_name }} {{ v.name }}</a>
                 </li>
             {% endfor %}
         </ul>

--- a/cbv/templates/cbv/klass_detail.html
+++ b/cbv/templates/cbv/klass_detail.html
@@ -5,7 +5,7 @@
 {% load static %}
 
 
-{% block title %}{{ klass }}{% endblock %}
+{% block title %}{{ klass.name }}{% endblock %}
 
 
 {% block meta_description %}
@@ -41,7 +41,7 @@
 
 {% block page_header %}
     <h1><small>class</small>&nbsp;{{ klass.name }}</h1>
-    <pre>from {{ klass.import_path }} import {{ klass }}</pre>
+    <pre>from {{ klass.import_path }} import {{ klass.name }}</pre>
     <div class="pull-right">
         {% with url=yuml_url %}
             {% if url %}
@@ -72,7 +72,7 @@
                         <div class="span4">
                         <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
                         <ol start='0' id="ancestors">
-                        <li><strong>{{ klass }}</strong></li>
+                        <li><strong>{{ klass.name }}</strong></li>
                     {% endif %}
                     <li>
                         <a href="{{ ancestor.get_absolute_url }}" class="{% if ancestor in direct_ancestors %}direct{% endif %}">
@@ -88,7 +88,7 @@
                     <h2>Descendants</h2>
                     <ul class="unstyled">
                     {% endif %}
-                        <li><a href="{{ child.get_absolute_url }}">{{ child }}</a></li>
+                        <li><a href="{{ child.get_absolute_url }}">{{ child.name }}</a></li>
                     {% if forloop.last %}</ul></div>{% endif %}
                 {% endfor %}
             {% endwith %}
@@ -116,9 +116,9 @@
                                 </td>
                                 <td>
                                     {% if attribute.klass == klass %}
-                                        {{ attribute.klass }}
+                                        {{ attribute.klass.name }}
                                     {% else %}
-                                        <a href="{{ attribute.klass.get_absolute_url }}">{{ attribute.klass }}</a>
+                                        <a href="{{ attribute.klass.get_absolute_url }}">{{ attribute.klass.name }}</a>
                                     {% endif %}
                                 </td>
                             </tr>
@@ -149,7 +149,7 @@
                                     <span class="nf">{{ method.name }}</span>(<span class="n">{{ method.kwargs }}</span>):
                                 </code>
                                 {% if namesakes|length == 1 %}
-                                    <small class="pull-right">{{ method.klass }}</small>
+                                    <small class="pull-right">{{ method.klass.name }}</small>
                                 {% endif %}
                                 <a class="permalink" href="{{ klass.get_absolute_url }}#{{ method.name }}">&para;</a>
                             </h3>
@@ -159,9 +159,9 @@
                                 {% if namesakes|length != 1 %}
                                     <details class="namesake accordion-group">
                                         <summary class="accordion-heading">
-                                            <h4 class="accordion-toggle">{{ namesake.klass }}</h4>
+                                            <h4 class="accordion-toggle">{{ namesake.klass.name }}</h4>
                                         </summary>
-                                        <div id="{{ namesake.name }}-{{ namesake.klass }}" class="accordion-body">
+                                        <div id="{{ namesake.name }}-{{ namesake.klass.name }}" class="accordion-body">
                                             <div class="accordion-inner">
                                                 {% if namesake.docstring %}<pre class="docstring">{{ namesake.docstring }}</pre>{% endif %}
                                                 {% pygmy namesake.code linenos='True' linenostart=namesake.line_number lexer='python' %}

--- a/cbv/templates/cbv/klass_detail.html
+++ b/cbv/templates/cbv/klass_detail.html
@@ -9,7 +9,7 @@
 
 
 {% block meta_description %}
-    {{ klass.name }} in {{ projectversion }}.
+    {{ klass.name }} in {{ project }}.
     {% if klass.docstring %}
         {{ klass.docstring }}
     {% endif %}

--- a/cbv/templates/cbv/module_detail.html
+++ b/cbv/templates/cbv/module_detail.html
@@ -1,14 +1,14 @@
 {% extends 'base.html' %}
 
 
-{% block title %}{{ module }}{% endblock %}
+{% block title %}{{ module_name }}{% endblock %}
 
 
 {% block nav %}
     {% include "cbv/includes/nav.html" %}
 {% endblock nav %}
 
-{% block page_header %}<h1>{{ module }}</h1>{% endblock %}
+{% block page_header %}<h1>{{ module_name }}</h1>{% endblock %}
 
 
 {% block content %}

--- a/cbv/templates/cbv/version_detail.html
+++ b/cbv/templates/cbv/version_detail.html
@@ -2,11 +2,11 @@
 
 {% load static %}
 
-{% block title %}{{ projectversion }}{% endblock %}
+{% block title %}{{ project }}{% endblock %}
 
 
 {% block meta_description %}
-    Class-based views in {{ projectversion }}.
+    Class-based views in {{ project }}.
 {% endblock meta_description %}
 
 
@@ -20,7 +20,7 @@
         <div id='klass-buttons'>
             <span class="btn btn-small" id="toggle-secondary-klasses">Show more</span>
         </div>
-        <h1>{{ projectversion }}</h1>
+        <h1>{{ project }}</h1>
         <div class="row">
             {% include 'cbv/_klass_list.html' with column_width=6 %}
         </div>

--- a/cbv/templates/home.html
+++ b/cbv/templates/home.html
@@ -29,7 +29,7 @@
             <div id='klass-buttons'>
                 <span class="btn btn-small" id="toggle-secondary-klasses">Show more</span>
             </div>
-            <h2>Start Here for {{ projectversion }}.</h2>
+            <h2>Start Here for {{ project }}.</h2>
             <div class="row">
                 {% include 'cbv/_klass_list.html' with column_width=3 %}
             </div>

--- a/cbv/views.py
+++ b/cbv/views.py
@@ -134,7 +134,7 @@ class ModuleDetailView(TemplateView):
         return {
             "canonical_url": self.request.build_absolute_uri(canonical_url_path),
             "klass_list": klass_list,
-            "module": module,
+            "module_name": module.name,
             "nav": nav,
             "project": f"Django {self.project_version.version_number}",
             "push_state_url": self.push_state_url,

--- a/cbv/views.py
+++ b/cbv/views.py
@@ -53,7 +53,7 @@ class KlassDetailView(TemplateView):
             "klass": klass,
             "methods": list(klass.get_methods()),
             "nav": nav,
-            "projectversion": klass.module.project_version,
+            "project": f"Django {klass.module.project_version.version_number}",
             "push_state_url": push_state_url,
             "version_switcher": version_switcher,
             "yuml_url": klass.basic_yuml_url(),
@@ -136,7 +136,7 @@ class ModuleDetailView(TemplateView):
             "klass_list": klass_list,
             "module": module,
             "nav": nav,
-            "projectversion": self.project_version,
+            "project": f"Django {self.project_version.version_number}",
             "push_state_url": self.push_state_url,
             "version_switcher": version_switcher,
         }
@@ -162,7 +162,7 @@ class VersionDetailView(TemplateView):
                     module__project_version=project_version
                 ).select_related("module__project_version")
             ),
-            "projectversion": str(project_version),
+            "project": f"Django {project_version.version_number}",
             "version_switcher": version_switcher,
         }
 
@@ -182,7 +182,7 @@ class HomeView(TemplateView):
                     module__project_version=project_version
                 ).select_related("module__project_version")
             ),
-            "projectversion": str(project_version),
+            "project": f"Django {project_version.version_number}",
             "version_switcher": version_switcher,
         }
 


### PR DESCRIPTION
Before this change, we relied on a string representation of the models in the UI, but display logic should not belong on models.

We now build the display information outside the models as required.

These methods might still be useful for debugging, but as we're on a journey to remove the models altogether, I don't think they're worth keeping.