### PR TITLE
Remove PostgreSQL support

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,21 +6,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    services:
-      postgres:
-        image: postgres:13.4
-        env:
-          POSTGRES_DB: ccbv
-          POSTGRES_USER: classy
-          POSTGRES_PASSWORD: classy
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - name: Clone code
         uses: actions/checkout@v3
@@ -42,8 +27,6 @@ jobs:
           pre-commit run --all-files --show-diff-on-failure
 
       - name: Run Python tests
-        env:
-          DATABASE_URL: postgres://classy:classy@localhost/ccbv
         run: |
           make test
 

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ build: _uv
 	uv pip install -r requirements.prod.txt -r requirements.dev.txt
 	python manage.py collectstatic --no-input
 	rm --force ccbv.sqlite
-	DATABASE_URL=sqlite:///ccbv.sqlite python manage.py migrate
-	DATABASE_URL=sqlite:///ccbv.sqlite python manage.py load_all_django_versions
+	python manage.py migrate
+	python manage.py load_all_django_versions
 
 run-prod:
-	DATABASE_URL=sqlite:///ccbv.sqlite gunicorn core.wsgi --log-file -
+	gunicorn core.wsgi --log-file -
 
 compile: _uv
 	uv pip compile requirements.prod.in --output-file=requirements.prod.txt

--- a/core/settings.py
+++ b/core/settings.py
@@ -46,9 +46,7 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "core.wsgi.application"
 
-DATABASES = {
-    "default": env.dj_db_url("DATABASE_URL", default="postgres://localhost/ccbv")
-}
+DATABASES = {"default": env.dj_db_url("DATABASE_URL", default="sqlite:///ccbv.sqlite")}
 
 LANGUAGE_CODE = "en"
 TIME_ZONE = "Europe/London"

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,0 @@
-# gets directory path, required to set up sqlite db file
-DIR_PATH=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-
-export DEBUG='True'
-export DATABASE_URL='sqlite:///'$DIR_PATH'/db.sqlite'
-export STATIC_URL='/static_media/'

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -6,7 +6,6 @@ django-pygmy
 django-sans-db>=1.2.0
 environs[django]
 gunicorn
-psycopg2-binary>=2.9.5
 requests
 # New versions aren't supported yet
 sphinx==1.2.2

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -42,8 +42,6 @@ marshmallow==3.18.0
     # via environs
 packaging==21.3
     # via marshmallow
-psycopg2-binary==2.9.5
-    # via -r requirements.prod.in
 pygments==2.10.0
     # via
     #   django-pygmy

--- a/tests/_page_snapshots/fuzzy-klass-detail-old.html
+++ b/tests/_page_snapshots/fuzzy-klass-detail-old.html
@@ -672,6 +672,54 @@
                             <h3>
                                 <code class="signature highlight">
                                     <span class="k">def</span>
+                                    <span class="nf">__init__</span>(<span class="n">self, **kwargs</span>):
+                                </code>
+                                
+                                    <small class="pull-right">View</small>
+                                
+                                <a class="permalink" href="/projects/Django/3.2/django.views.generic.edit/FormView/#__init__">&para;</a>
+                            </h3>
+                        </summary>
+                        <div id="__init__" class="accordion-body">
+                            
+                                
+                                    <pre class="docstring">Constructor. Called in the URLconf; can contain helpful extra
+keyword arguments, and other things.</pre>
+                                    <table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">38</span>
+<span class="normal">39</span>
+<span class="normal">40</span>
+<span class="normal">41</span>
+<span class="normal">42</span>
+<span class="normal">43</span>
+<span class="normal">44</span>
+<span class="normal">45</span>
+<span class="normal">46</span></pre></div></td><td class="code"><div class="highlight"><pre><span></span><span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+    <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">    Constructor. Called in the URLconf; can contain helpful extra</span>
+<span class="sd">    keyword arguments, and other things.</span>
+<span class="sd">    &quot;&quot;&quot;</span>
+    <span class="c1"># Go through keyword arguments, and either save their values to our</span>
+    <span class="c1"># instance, or raise an error.</span>
+    <span class="k">for</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="ow">in</span> <span class="n">kwargs</span><span class="o">.</span><span class="n">items</span><span class="p">():</span>
+        <span class="nb">setattr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">)</span>
+</pre></div>
+</td></tr></table>
+                                
+                            
+                        </div>
+                    </details>
+                    
+                
+                
+            
+                
+                
+                    
+                    <details class="method accordion-group">
+                        <summary class="accordion-heading btn">
+                            <h3>
+                                <code class="signature highlight">
+                                    <span class="k">def</span>
                                     <span class="nf">_allowed_methods</span>(<span class="n">self</span>):
                                 </code>
                                 
@@ -1331,54 +1379,6 @@ a list. May not be called if render_to_response() is overridden.</pre>
         <span class="n">extra</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;status_code&#39;</span><span class="p">:</span> <span class="mi">405</span><span class="p">,</span> <span class="s1">&#39;request&#39;</span><span class="p">:</span> <span class="n">request</span><span class="p">}</span>
     <span class="p">)</span>
     <span class="k">return</span> <span class="n">HttpResponseNotAllowed</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">_allowed_methods</span><span class="p">())</span>
-</pre></div>
-</td></tr></table>
-                                
-                            
-                        </div>
-                    </details>
-                    
-                
-                
-            
-                
-                
-                    
-                    <details class="method accordion-group">
-                        <summary class="accordion-heading btn">
-                            <h3>
-                                <code class="signature highlight">
-                                    <span class="k">def</span>
-                                    <span class="nf">__init__</span>(<span class="n">self, **kwargs</span>):
-                                </code>
-                                
-                                    <small class="pull-right">View</small>
-                                
-                                <a class="permalink" href="/projects/Django/3.2/django.views.generic.edit/FormView/#__init__">&para;</a>
-                            </h3>
-                        </summary>
-                        <div id="__init__" class="accordion-body">
-                            
-                                
-                                    <pre class="docstring">Constructor. Called in the URLconf; can contain helpful extra
-keyword arguments, and other things.</pre>
-                                    <table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">38</span>
-<span class="normal">39</span>
-<span class="normal">40</span>
-<span class="normal">41</span>
-<span class="normal">42</span>
-<span class="normal">43</span>
-<span class="normal">44</span>
-<span class="normal">45</span>
-<span class="normal">46</span></pre></div></td><td class="code"><div class="highlight"><pre><span></span><span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Constructor. Called in the URLconf; can contain helpful extra</span>
-<span class="sd">    keyword arguments, and other things.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="c1"># Go through keyword arguments, and either save their values to our</span>
-    <span class="c1"># instance, or raise an error.</span>
-    <span class="k">for</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="ow">in</span> <span class="n">kwargs</span><span class="o">.</span><span class="n">items</span><span class="p">():</span>
-        <span class="nb">setattr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">)</span>
 </pre></div>
 </td></tr></table>
                                 

--- a/tests/_page_snapshots/fuzzy-klass-detail-old.html
+++ b/tests/_page_snapshots/fuzzy-klass-detail-old.html
@@ -37,9 +37,7 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    
-
-<li class="dropdown">
+    <li class="dropdown">
     
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             Django 3.2 <b class="caret"></b>
@@ -379,7 +377,6 @@
             </ul>
         </li>
     
-
 
 
 

--- a/tests/_page_snapshots/fuzzy-klass-detail.html
+++ b/tests/_page_snapshots/fuzzy-klass-detail.html
@@ -37,9 +37,7 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    
-
-<li class="dropdown">
+    <li class="dropdown">
     
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -379,7 +377,6 @@
             </ul>
         </li>
     
-
 
 
 

--- a/tests/_page_snapshots/fuzzy-klass-detail.html
+++ b/tests/_page_snapshots/fuzzy-klass-detail.html
@@ -672,6 +672,54 @@
                             <h3>
                                 <code class="signature highlight">
                                     <span class="k">def</span>
+                                    <span class="nf">__init__</span>(<span class="n">self, **kwargs</span>):
+                                </code>
+                                
+                                    <small class="pull-right">View</small>
+                                
+                                <a class="permalink" href="/projects/Django/4.0/django.views.generic.edit/FormView/#__init__">&para;</a>
+                            </h3>
+                        </summary>
+                        <div id="__init__" class="accordion-body">
+                            
+                                
+                                    <pre class="docstring">Constructor. Called in the URLconf; can contain helpful extra
+keyword arguments, and other things.</pre>
+                                    <table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">37</span>
+<span class="normal">38</span>
+<span class="normal">39</span>
+<span class="normal">40</span>
+<span class="normal">41</span>
+<span class="normal">42</span>
+<span class="normal">43</span>
+<span class="normal">44</span>
+<span class="normal">45</span></pre></div></td><td class="code"><div class="highlight"><pre><span></span><span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+    <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">    Constructor. Called in the URLconf; can contain helpful extra</span>
+<span class="sd">    keyword arguments, and other things.</span>
+<span class="sd">    &quot;&quot;&quot;</span>
+    <span class="c1"># Go through keyword arguments, and either save their values to our</span>
+    <span class="c1"># instance, or raise an error.</span>
+    <span class="k">for</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="ow">in</span> <span class="n">kwargs</span><span class="o">.</span><span class="n">items</span><span class="p">():</span>
+        <span class="nb">setattr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">)</span>
+</pre></div>
+</td></tr></table>
+                                
+                            
+                        </div>
+                    </details>
+                    
+                
+                
+            
+                
+                
+                    
+                    <details class="method accordion-group">
+                        <summary class="accordion-heading btn">
+                            <h3>
+                                <code class="signature highlight">
+                                    <span class="k">def</span>
                                     <span class="nf">_allowed_methods</span>(<span class="n">self</span>):
                                 </code>
                                 
@@ -1339,54 +1387,6 @@ a list. May not be called if render_to_response() is overridden.</pre>
         <span class="n">extra</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;status_code&#39;</span><span class="p">:</span> <span class="mi">405</span><span class="p">,</span> <span class="s1">&#39;request&#39;</span><span class="p">:</span> <span class="n">request</span><span class="p">}</span>
     <span class="p">)</span>
     <span class="k">return</span> <span class="n">HttpResponseNotAllowed</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">_allowed_methods</span><span class="p">())</span>
-</pre></div>
-</td></tr></table>
-                                
-                            
-                        </div>
-                    </details>
-                    
-                
-                
-            
-                
-                
-                    
-                    <details class="method accordion-group">
-                        <summary class="accordion-heading btn">
-                            <h3>
-                                <code class="signature highlight">
-                                    <span class="k">def</span>
-                                    <span class="nf">__init__</span>(<span class="n">self, **kwargs</span>):
-                                </code>
-                                
-                                    <small class="pull-right">View</small>
-                                
-                                <a class="permalink" href="/projects/Django/4.0/django.views.generic.edit/FormView/#__init__">&para;</a>
-                            </h3>
-                        </summary>
-                        <div id="__init__" class="accordion-body">
-                            
-                                
-                                    <pre class="docstring">Constructor. Called in the URLconf; can contain helpful extra
-keyword arguments, and other things.</pre>
-                                    <table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">37</span>
-<span class="normal">38</span>
-<span class="normal">39</span>
-<span class="normal">40</span>
-<span class="normal">41</span>
-<span class="normal">42</span>
-<span class="normal">43</span>
-<span class="normal">44</span>
-<span class="normal">45</span></pre></div></td><td class="code"><div class="highlight"><pre><span></span><span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Constructor. Called in the URLconf; can contain helpful extra</span>
-<span class="sd">    keyword arguments, and other things.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="c1"># Go through keyword arguments, and either save their values to our</span>
-    <span class="c1"># instance, or raise an error.</span>
-    <span class="k">for</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="ow">in</span> <span class="n">kwargs</span><span class="o">.</span><span class="n">items</span><span class="p">():</span>
-        <span class="nb">setattr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">)</span>
 </pre></div>
 </td></tr></table>
                                 

--- a/tests/_page_snapshots/fuzzy-module-detail.html
+++ b/tests/_page_snapshots/fuzzy-module-detail.html
@@ -32,9 +32,7 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    
-
-<li class="dropdown">
+    <li class="dropdown">
     
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -374,7 +372,6 @@
             </ul>
         </li>
     
-
 
 
 

--- a/tests/_page_snapshots/homepage.html
+++ b/tests/_page_snapshots/homepage.html
@@ -26,9 +26,7 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    
-
-<li class="dropdown">
+    <li class="dropdown">
     
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -368,7 +366,6 @@
             </ul>
         </li>
     
-
 
 
 

--- a/tests/_page_snapshots/klass-detail-old.html
+++ b/tests/_page_snapshots/klass-detail-old.html
@@ -33,9 +33,7 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    
-
-<li class="dropdown">
+    <li class="dropdown">
     
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             Django 3.2 <b class="caret"></b>
@@ -375,7 +373,6 @@
             </ul>
         </li>
     
-
 
 
 

--- a/tests/_page_snapshots/klass-detail-old.html
+++ b/tests/_page_snapshots/klass-detail-old.html
@@ -668,6 +668,54 @@
                             <h3>
                                 <code class="signature highlight">
                                     <span class="k">def</span>
+                                    <span class="nf">__init__</span>(<span class="n">self, **kwargs</span>):
+                                </code>
+                                
+                                    <small class="pull-right">View</small>
+                                
+                                <a class="permalink" href="/projects/Django/3.2/django.views.generic.edit/FormView/#__init__">&para;</a>
+                            </h3>
+                        </summary>
+                        <div id="__init__" class="accordion-body">
+                            
+                                
+                                    <pre class="docstring">Constructor. Called in the URLconf; can contain helpful extra
+keyword arguments, and other things.</pre>
+                                    <table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">38</span>
+<span class="normal">39</span>
+<span class="normal">40</span>
+<span class="normal">41</span>
+<span class="normal">42</span>
+<span class="normal">43</span>
+<span class="normal">44</span>
+<span class="normal">45</span>
+<span class="normal">46</span></pre></div></td><td class="code"><div class="highlight"><pre><span></span><span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+    <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">    Constructor. Called in the URLconf; can contain helpful extra</span>
+<span class="sd">    keyword arguments, and other things.</span>
+<span class="sd">    &quot;&quot;&quot;</span>
+    <span class="c1"># Go through keyword arguments, and either save their values to our</span>
+    <span class="c1"># instance, or raise an error.</span>
+    <span class="k">for</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="ow">in</span> <span class="n">kwargs</span><span class="o">.</span><span class="n">items</span><span class="p">():</span>
+        <span class="nb">setattr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">)</span>
+</pre></div>
+</td></tr></table>
+                                
+                            
+                        </div>
+                    </details>
+                    
+                
+                
+            
+                
+                
+                    
+                    <details class="method accordion-group">
+                        <summary class="accordion-heading btn">
+                            <h3>
+                                <code class="signature highlight">
+                                    <span class="k">def</span>
                                     <span class="nf">_allowed_methods</span>(<span class="n">self</span>):
                                 </code>
                                 
@@ -1327,54 +1375,6 @@ a list. May not be called if render_to_response() is overridden.</pre>
         <span class="n">extra</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;status_code&#39;</span><span class="p">:</span> <span class="mi">405</span><span class="p">,</span> <span class="s1">&#39;request&#39;</span><span class="p">:</span> <span class="n">request</span><span class="p">}</span>
     <span class="p">)</span>
     <span class="k">return</span> <span class="n">HttpResponseNotAllowed</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">_allowed_methods</span><span class="p">())</span>
-</pre></div>
-</td></tr></table>
-                                
-                            
-                        </div>
-                    </details>
-                    
-                
-                
-            
-                
-                
-                    
-                    <details class="method accordion-group">
-                        <summary class="accordion-heading btn">
-                            <h3>
-                                <code class="signature highlight">
-                                    <span class="k">def</span>
-                                    <span class="nf">__init__</span>(<span class="n">self, **kwargs</span>):
-                                </code>
-                                
-                                    <small class="pull-right">View</small>
-                                
-                                <a class="permalink" href="/projects/Django/3.2/django.views.generic.edit/FormView/#__init__">&para;</a>
-                            </h3>
-                        </summary>
-                        <div id="__init__" class="accordion-body">
-                            
-                                
-                                    <pre class="docstring">Constructor. Called in the URLconf; can contain helpful extra
-keyword arguments, and other things.</pre>
-                                    <table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">38</span>
-<span class="normal">39</span>
-<span class="normal">40</span>
-<span class="normal">41</span>
-<span class="normal">42</span>
-<span class="normal">43</span>
-<span class="normal">44</span>
-<span class="normal">45</span>
-<span class="normal">46</span></pre></div></td><td class="code"><div class="highlight"><pre><span></span><span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Constructor. Called in the URLconf; can contain helpful extra</span>
-<span class="sd">    keyword arguments, and other things.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="c1"># Go through keyword arguments, and either save their values to our</span>
-    <span class="c1"># instance, or raise an error.</span>
-    <span class="k">for</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="ow">in</span> <span class="n">kwargs</span><span class="o">.</span><span class="n">items</span><span class="p">():</span>
-        <span class="nb">setattr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">)</span>
 </pre></div>
 </td></tr></table>
                                 

--- a/tests/_page_snapshots/klass-detail.html
+++ b/tests/_page_snapshots/klass-detail.html
@@ -668,6 +668,54 @@
                             <h3>
                                 <code class="signature highlight">
                                     <span class="k">def</span>
+                                    <span class="nf">__init__</span>(<span class="n">self, **kwargs</span>):
+                                </code>
+                                
+                                    <small class="pull-right">View</small>
+                                
+                                <a class="permalink" href="/projects/Django/4.0/django.views.generic.edit/FormView/#__init__">&para;</a>
+                            </h3>
+                        </summary>
+                        <div id="__init__" class="accordion-body">
+                            
+                                
+                                    <pre class="docstring">Constructor. Called in the URLconf; can contain helpful extra
+keyword arguments, and other things.</pre>
+                                    <table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">37</span>
+<span class="normal">38</span>
+<span class="normal">39</span>
+<span class="normal">40</span>
+<span class="normal">41</span>
+<span class="normal">42</span>
+<span class="normal">43</span>
+<span class="normal">44</span>
+<span class="normal">45</span></pre></div></td><td class="code"><div class="highlight"><pre><span></span><span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+    <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">    Constructor. Called in the URLconf; can contain helpful extra</span>
+<span class="sd">    keyword arguments, and other things.</span>
+<span class="sd">    &quot;&quot;&quot;</span>
+    <span class="c1"># Go through keyword arguments, and either save their values to our</span>
+    <span class="c1"># instance, or raise an error.</span>
+    <span class="k">for</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="ow">in</span> <span class="n">kwargs</span><span class="o">.</span><span class="n">items</span><span class="p">():</span>
+        <span class="nb">setattr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">)</span>
+</pre></div>
+</td></tr></table>
+                                
+                            
+                        </div>
+                    </details>
+                    
+                
+                
+            
+                
+                
+                    
+                    <details class="method accordion-group">
+                        <summary class="accordion-heading btn">
+                            <h3>
+                                <code class="signature highlight">
+                                    <span class="k">def</span>
                                     <span class="nf">_allowed_methods</span>(<span class="n">self</span>):
                                 </code>
                                 
@@ -1335,54 +1383,6 @@ a list. May not be called if render_to_response() is overridden.</pre>
         <span class="n">extra</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;status_code&#39;</span><span class="p">:</span> <span class="mi">405</span><span class="p">,</span> <span class="s1">&#39;request&#39;</span><span class="p">:</span> <span class="n">request</span><span class="p">}</span>
     <span class="p">)</span>
     <span class="k">return</span> <span class="n">HttpResponseNotAllowed</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">_allowed_methods</span><span class="p">())</span>
-</pre></div>
-</td></tr></table>
-                                
-                            
-                        </div>
-                    </details>
-                    
-                
-                
-            
-                
-                
-                    
-                    <details class="method accordion-group">
-                        <summary class="accordion-heading btn">
-                            <h3>
-                                <code class="signature highlight">
-                                    <span class="k">def</span>
-                                    <span class="nf">__init__</span>(<span class="n">self, **kwargs</span>):
-                                </code>
-                                
-                                    <small class="pull-right">View</small>
-                                
-                                <a class="permalink" href="/projects/Django/4.0/django.views.generic.edit/FormView/#__init__">&para;</a>
-                            </h3>
-                        </summary>
-                        <div id="__init__" class="accordion-body">
-                            
-                                
-                                    <pre class="docstring">Constructor. Called in the URLconf; can contain helpful extra
-keyword arguments, and other things.</pre>
-                                    <table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">37</span>
-<span class="normal">38</span>
-<span class="normal">39</span>
-<span class="normal">40</span>
-<span class="normal">41</span>
-<span class="normal">42</span>
-<span class="normal">43</span>
-<span class="normal">44</span>
-<span class="normal">45</span></pre></div></td><td class="code"><div class="highlight"><pre><span></span><span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Constructor. Called in the URLconf; can contain helpful extra</span>
-<span class="sd">    keyword arguments, and other things.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="c1"># Go through keyword arguments, and either save their values to our</span>
-    <span class="c1"># instance, or raise an error.</span>
-    <span class="k">for</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="ow">in</span> <span class="n">kwargs</span><span class="o">.</span><span class="n">items</span><span class="p">():</span>
-        <span class="nb">setattr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">)</span>
 </pre></div>
 </td></tr></table>
                                 

--- a/tests/_page_snapshots/klass-detail.html
+++ b/tests/_page_snapshots/klass-detail.html
@@ -33,9 +33,7 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    
-
-<li class="dropdown">
+    <li class="dropdown">
     
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -375,7 +373,6 @@
             </ul>
         </li>
     
-
 
 
 

--- a/tests/_page_snapshots/module-detail.html
+++ b/tests/_page_snapshots/module-detail.html
@@ -28,9 +28,7 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    
-
-<li class="dropdown">
+    <li class="dropdown">
     
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -370,7 +368,6 @@
             </ul>
         </li>
     
-
 
 
 

--- a/tests/_page_snapshots/version-detail.html
+++ b/tests/_page_snapshots/version-detail.html
@@ -28,9 +28,7 @@
                 <a class="brand" href="/">ccbv.co.uk</a>
                 <ul class="nav">
                 
-    
-
-<li class="dropdown">
+    <li class="dropdown">
     
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             Django 4.0 <b class="caret"></b>
@@ -370,7 +368,6 @@
             </ul>
         </li>
     
-
 
 
 


### PR DESCRIPTION
We use SQLite in production, and our makefile configured things to use SQLite too.

We're trying to move away from needing a database at all, so it makes sense to remove this unused support.

As a bonus, this cuts about 22 seconds off our CI build time.