### PR TITLE
Reduce dependency on models in templates

### DIFF
--- a/cbv/templates/cbv/_klass_list.html
+++ b/cbv/templates/cbv/_klass_list.html
@@ -1,14 +1,14 @@
 <div class="span{{ column_width }}">
 {% for obj in object_list %}
-    {% ifchanged obj.module.name %}
+    {% ifchanged obj.module_name %}
         {% if not forloop.first %}</ul></div>{% endif %}
-        {% if obj.module.short_name == 'detail'%}</div><div class="span{{ column_width }}">{% endif %}
+        {% if obj.module_short_name == 'detail'%}</div><div class="span{{ column_width }}">{% endif %}
         <div class="well skinny klass-list">
         <ul class="nav nav-list">
-        <li class="nav-header"><h3>{{ obj.module.long_name }}</h3></li>
+        <li class="nav-header"><h3>{{ obj.module_long_name }}</h3></li>
     {% endifchanged %}
     <li class="{% if obj.is_secondary %}secondary{% else %}primary{% endif %}">
-        <a href="{{ obj.get_absolute_url }}" {% if obj.docstring %}class="klass-tooltip" data-original-title="{{ obj.docstring }}" data-placement="bottom"{% endif %}>
+        <a href="{{ obj.url }}" {% if obj.docstring %}class="klass-tooltip" data-original-title="{{ obj.docstring }}" data-placement="bottom"{% endif %}>
             {{ obj.name }}
         </a>
     </li>

--- a/cbv/templates/cbv/klass_detail.html
+++ b/cbv/templates/cbv/klass_detail.html
@@ -83,7 +83,7 @@
             {% endif %}
 
             {% if all_children %}
-                <div id="descendants" class="span{% if direct_ancestors %}8{% else %}12{% endif %}">
+                <div id="descendants" class="span{% if all_ancestors %}8{% else %}12{% endif %}">
                     <h2>Descendants</h2>
                     <ul class="unstyled">
                         {% for child in all_children %}

--- a/cbv/templates/cbv/klass_detail.html
+++ b/cbv/templates/cbv/klass_detail.html
@@ -66,30 +66,30 @@
 {% block content %}
     <div class="span12">
         <div class="row">
-                {% for ancestor in all_ancestors %}
-                    {% if forloop.first %}
-                        <div class="span4">
-                        <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
-                        <ol start='0' id="ancestors">
-                        <li><strong>{{ klass.name }}</strong></li>
-                    {% endif %}
-                    <li>
-                        <a href="{{ ancestor.get_absolute_url }}" class="{% if ancestor in direct_ancestors %}direct{% endif %}">
-                            {{ ancestor.name }}
-                        </a>
-                    </li>
-                    {% if forloop.last %}</ol></div>{% endif %}
-                {% endfor %}
+            {% for ancestor in all_ancestors %}
+                {% if forloop.first %}
+                    <div class="span4">
+                    <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
+                    <ol start='0' id="ancestors">
+                    <li><strong>{{ klass.name }}</strong></li>
+                {% endif %}
+                <li>
+                    <a href="{{ ancestor.get_absolute_url }}" class="{% if ancestor in direct_ancestors %}direct{% endif %}">
+                        {{ ancestor.name }}
+                    </a>
+                </li>
+                {% if forloop.last %}</ol></div>{% endif %}
+            {% endfor %}
 
-                {% for child in all_children %}
-                    {% if forloop.first %}
-                    <div id="descendants" class="span{% if direct_ancestors %}8{% else %}12{% endif %}">
-                    <h2>Descendants</h2>
-                    <ul class="unstyled">
-                    {% endif %}
-                        <li><a href="{{ child.get_absolute_url }}">{{ child.name }}</a></li>
-                    {% if forloop.last %}</ul></div>{% endif %}
-                {% endfor %}
+            {% for child in all_children %}
+                {% if forloop.first %}
+                <div id="descendants" class="span{% if direct_ancestors %}8{% else %}12{% endif %}">
+                <h2>Descendants</h2>
+                <ul class="unstyled">
+                {% endif %}
+                    <li><a href="{{ child.get_absolute_url }}">{{ child.name }}</a></li>
+                {% if forloop.last %}</ul></div>{% endif %}
+            {% endfor %}
         </div>
 
         <div class="row">

--- a/cbv/templates/cbv/klass_detail.html
+++ b/cbv/templates/cbv/klass_detail.html
@@ -66,30 +66,32 @@
 {% block content %}
     <div class="span12">
         <div class="row">
-            {% for ancestor in all_ancestors %}
-                {% if forloop.first %}
-                    <div class="span4">
+            {% if all_ancestors %}
+                <div class="span4">
                     <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
                     <ol start='0' id="ancestors">
-                    <li><strong>{{ klass.name }}</strong></li>
-                {% endif %}
-                <li>
-                    <a href="{{ ancestor.get_absolute_url }}" class="{% if ancestor in direct_ancestors %}direct{% endif %}">
-                        {{ ancestor.name }}
-                    </a>
-                </li>
-                {% if forloop.last %}</ol></div>{% endif %}
-            {% endfor %}
+                        <li><strong>{{ klass.name }}</strong></li>
+                        {% for ancestor in all_ancestors %}
+                            <li>
+                                <a href="{{ ancestor.get_absolute_url }}" class="{% if ancestor in direct_ancestors %}direct{% endif %}">
+                                    {{ ancestor.name }}
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ol>
+                </div>
+            {% endif %}
 
-            {% for child in all_children %}
-                {% if forloop.first %}
+            {% if all_children %}
                 <div id="descendants" class="span{% if direct_ancestors %}8{% else %}12{% endif %}">
-                <h2>Descendants</h2>
-                <ul class="unstyled">
-                {% endif %}
-                    <li><a href="{{ child.get_absolute_url }}">{{ child.name }}</a></li>
-                {% if forloop.last %}</ul></div>{% endif %}
-            {% endfor %}
+                    <h2>Descendants</h2>
+                    <ul class="unstyled">
+                        {% for child in all_children %}
+                            <li><a href="{{ child.get_absolute_url }}">{{ child.name }}</a></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            {% endif %}
         </div>
 
         <div class="row">

--- a/cbv/templates/cbv/klass_detail.html
+++ b/cbv/templates/cbv/klass_detail.html
@@ -35,7 +35,7 @@
 
 
 {% block nav %}
-    {% include "cbv/includes/nav.html" %}
+    {% include "cbv/includes/nav.html" with nav=nav version_switcher=version_switcher only %}
 {% endblock nav %}
 
 

--- a/cbv/templates/cbv/klass_detail.html
+++ b/cbv/templates/cbv/klass_detail.html
@@ -66,7 +66,6 @@
 {% block content %}
     <div class="span12">
         <div class="row">
-            {% with klass.get_ancestors as direct_ancestors %}
                 {% for ancestor in all_ancestors %}
                     {% if forloop.first %}
                         <div class="span4">
@@ -91,7 +90,6 @@
                         <li><a href="{{ child.get_absolute_url }}">{{ child.name }}</a></li>
                     {% if forloop.last %}</ul></div>{% endif %}
                 {% endfor %}
-            {% endwith %}
         </div>
 
         <div class="row">

--- a/cbv/templates/cbv/klass_detail.html
+++ b/cbv/templates/cbv/klass_detail.html
@@ -87,7 +87,7 @@
                     <h2>Descendants</h2>
                     <ul class="unstyled">
                         {% for child in all_children %}
-                            <li><a href="{{ child.get_absolute_url }}">{{ child.name }}</a></li>
+                            <li><a href="{{ child.url }}">{{ child.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </div>

--- a/cbv/templates/cbv/klass_detail.html
+++ b/cbv/templates/cbv/klass_detail.html
@@ -73,7 +73,7 @@
                         <li><strong>{{ klass.name }}</strong></li>
                         {% for ancestor in all_ancestors %}
                             <li>
-                                <a href="{{ ancestor.get_absolute_url }}" class="{% if ancestor in direct_ancestors %}direct{% endif %}">
+                                <a href="{{ ancestor.url }}" class="{% if ancestor.is_direct %}direct{% endif %}">
                                     {{ ancestor.name }}
                                 </a>
                             </li>

--- a/cbv/templates/cbv/module_detail.html
+++ b/cbv/templates/cbv/module_detail.html
@@ -5,7 +5,7 @@
 
 
 {% block nav %}
-    {% include "cbv/includes/nav.html" %}
+    {% include "cbv/includes/nav.html" with nav=nav version_switcher=version_switcher only %}
 {% endblock nav %}
 
 {% block page_header %}<h1>{{ module_name }}</h1>{% endblock %}

--- a/cbv/templates/cbv/version_detail.html
+++ b/cbv/templates/cbv/version_detail.html
@@ -11,7 +11,7 @@
 
 
 {% block nav %}
-    {% include "cbv/includes/nav.html" %}
+    {% include "cbv/includes/nav.html" with nav=nav version_switcher=version_switcher only %}
 {% endblock %}
 
 
@@ -22,7 +22,7 @@
         </div>
         <h1>{{ project }}</h1>
         <div class="row">
-            {% include 'cbv/_klass_list.html' with column_width=6 %}
+            {% include 'cbv/_klass_list.html' with column_width=6 object_list=object_list only %}
         </div>
     </div>
 {% endblock %}

--- a/cbv/templates/home.html
+++ b/cbv/templates/home.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block nav %}
-    {% include "cbv/includes/nav.html" %}
+    {% include "cbv/includes/nav.html" with nav=nav version_switcher=version_switcher only %}
 {% endblock %}
 
 
@@ -31,7 +31,7 @@
             </div>
             <h2>Start Here for {{ project }}.</h2>
             <div class="row">
-                {% include 'cbv/_klass_list.html' with column_width=3 %}
+                {% include 'cbv/_klass_list.html' with column_width=3 object_list=object_list only %}
             </div>
         </div>
     </div>

--- a/cbv/views.py
+++ b/cbv/views.py
@@ -142,6 +142,17 @@ class ModuleDetailView(TemplateView):
         }
 
 
+@attrs.frozen
+class DjangoClassListItem:
+    docstring: str
+    is_secondary: bool
+    name: str
+    module_long_name: str
+    module_name: str
+    module_short_name: str
+    url: str
+
+
 class VersionDetailView(TemplateView):
     template_name = "cbv/version_detail.html"
 
@@ -157,11 +168,20 @@ class VersionDetailView(TemplateView):
         nav = nav_builder.get_nav_data(project_version)
         return {
             "nav": nav,
-            "object_list": list(
-                Klass.objects.filter(
+            "object_list": [
+                DjangoClassListItem(
+                    docstring=class_.docstring,
+                    is_secondary=class_.is_secondary(),
+                    name=class_.name,
+                    module_long_name=class_.module.long_name,
+                    module_name=class_.module.name,
+                    module_short_name=class_.module.short_name,
+                    url=class_.get_absolute_url(),
+                )
+                for class_ in Klass.objects.filter(
                     module__project_version=project_version
                 ).select_related("module__project_version")
-            ),
+            ],
             "project": f"Django {project_version.version_number}",
             "version_switcher": version_switcher,
         }
@@ -177,11 +197,20 @@ class HomeView(TemplateView):
         nav = nav_builder.get_nav_data(project_version)
         return {
             "nav": nav,
-            "object_list": list(
-                Klass.objects.filter(
+            "object_list": [
+                DjangoClassListItem(
+                    docstring=class_.docstring,
+                    is_secondary=class_.is_secondary(),
+                    name=class_.name,
+                    module_long_name=class_.module.long_name,
+                    module_name=class_.module.name,
+                    module_short_name=class_.module.short_name,
+                    url=class_.get_absolute_url(),
+                )
+                for class_ in Klass.objects.filter(
                     module__project_version=project_version
                 ).select_related("module__project_version")
-            ),
+            ],
             "project": f"Django {project_version.version_number}",
             "version_switcher": version_switcher,
         }

--- a/cbv/views.py
+++ b/cbv/views.py
@@ -27,6 +27,11 @@ class KlassDetailView(TemplateView):
         url: str
         is_direct: bool
 
+    @attrs.frozen
+    class Child:
+        name: str
+        url: str
+
     def get_context_data(self, **kwargs):
         qs = Klass.objects.filter(
             name__iexact=self.kwargs["klass"],
@@ -60,9 +65,16 @@ class KlassDetailView(TemplateView):
             )
             for ancestor in klass.get_all_ancestors()
         ]
+        children = [
+            self.Child(
+                name=child.name,
+                url=child.get_absolute_url(),
+            )
+            for child in klass.get_all_children()
+        ]
         return {
             "all_ancestors": ancestors,
-            "all_children": list(klass.get_all_children()),
+            "all_children": children,
             "attributes": klass.get_prepared_attributes(),
             "canonical_url": self.request.build_absolute_uri(canonical_url_path),
             "direct_ancestors": direct_ancestors,

--- a/cbv/views.py
+++ b/cbv/views.py
@@ -77,7 +77,6 @@ class KlassDetailView(TemplateView):
             "all_children": children,
             "attributes": klass.get_prepared_attributes(),
             "canonical_url": self.request.build_absolute_uri(canonical_url_path),
-            "direct_ancestors": direct_ancestors,
             "klass": klass,
             "methods": list(klass.get_methods()),
             "nav": nav,

--- a/cbv/views.py
+++ b/cbv/views.py
@@ -45,11 +45,13 @@ class KlassDetailView(TemplateView):
         nav = nav_builder.get_nav_data(
             klass.module.project_version, klass.module, klass
         )
+        direct_ancestors = list(klass.get_ancestors())
         return {
             "all_ancestors": list(klass.get_all_ancestors()),
             "all_children": list(klass.get_all_children()),
             "attributes": klass.get_prepared_attributes(),
             "canonical_url": self.request.build_absolute_uri(canonical_url_path),
+            "direct_ancestors": direct_ancestors,
             "klass": klass,
             "methods": list(klass.get_methods()),
             "nav": nav,

--- a/tests/_page_snapshots/fuzzy-klass-detail-old.html
+++ b/tests/_page_snapshots/fuzzy-klass-detail-old.html
@@ -408,80 +408,66 @@
     <div class="span12">
         <div class="row">
             
-                
-                    <div class="span4">
+                <div class="span4">
                     <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
                     <ol start='0' id="ancestors">
-                    <li><strong>FormView</strong></li>
-                
-                <li>
-                    <a href="/projects/Django/3.2/django.views.generic.base/TemplateResponseMixin/" class="direct">
-                        TemplateResponseMixin
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/3.2/django.views.generic.edit/BaseFormView/" class="direct">
-                        BaseFormView
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/3.2/django.views.generic.edit/FormMixin/" class="">
-                        FormMixin
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/3.2/django.views.generic.base/ContextMixin/" class="">
-                        ContextMixin
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/3.2/django.views.generic.edit/ProcessFormView/" class="">
-                        ProcessFormView
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/3.2/django.views.generic.base/View/" class="">
-                        View
-                    </a>
-                </li>
-                </ol></div>
+                        <li><strong>FormView</strong></li>
+                        
+                            <li>
+                                <a href="/projects/Django/3.2/django.views.generic.base/TemplateResponseMixin/" class="direct">
+                                    TemplateResponseMixin
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/3.2/django.views.generic.edit/BaseFormView/" class="direct">
+                                    BaseFormView
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/3.2/django.views.generic.edit/FormMixin/" class="">
+                                    FormMixin
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/3.2/django.views.generic.base/ContextMixin/" class="">
+                                    ContextMixin
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/3.2/django.views.generic.edit/ProcessFormView/" class="">
+                                    ProcessFormView
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/3.2/django.views.generic.base/View/" class="">
+                                    View
+                                </a>
+                            </li>
+                        
+                    </ol>
+                </div>
             
 
             
-                
                 <div id="descendants" class="span8">
-                <h2>Descendants</h2>
-                <ul class="unstyled">
-                
-                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/LoginView/">LoginView</a></li>
-                
-            
-                
-                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
-                
-            
-                
-                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
-                
-            
-                
-                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
-                </ul></div>
+                    <h2>Descendants</h2>
+                    <ul class="unstyled">
+                        
+                            <li><a href="/projects/Django/3.2/django.contrib.auth.views/LoginView/">LoginView</a></li>
+                        
+                            <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
+                        
+                            <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
+                        
+                            <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
+                        
+                    </ul>
+                </div>
             
         </div>
 

--- a/tests/_page_snapshots/fuzzy-klass-detail-old.html
+++ b/tests/_page_snapshots/fuzzy-klass-detail-old.html
@@ -407,82 +407,82 @@
             <div class="row">
     <div class="span12">
         <div class="row">
+            
                 
-                    
-                        <div class="span4">
-                        <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
-                        <ol start='0' id="ancestors">
-                        <li><strong>FormView</strong></li>
-                    
-                    <li>
-                        <a href="/projects/Django/3.2/django.views.generic.base/TemplateResponseMixin/" class="direct">
-                            TemplateResponseMixin
-                        </a>
-                    </li>
-                    
+                    <div class="span4">
+                    <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
+                    <ol start='0' id="ancestors">
+                    <li><strong>FormView</strong></li>
                 
-                    
-                    <li>
-                        <a href="/projects/Django/3.2/django.views.generic.edit/BaseFormView/" class="direct">
-                            BaseFormView
-                        </a>
-                    </li>
-                    
+                <li>
+                    <a href="/projects/Django/3.2/django.views.generic.base/TemplateResponseMixin/" class="direct">
+                        TemplateResponseMixin
+                    </a>
+                </li>
                 
-                    
-                    <li>
-                        <a href="/projects/Django/3.2/django.views.generic.edit/FormMixin/" class="">
-                            FormMixin
-                        </a>
-                    </li>
-                    
+            
                 
-                    
-                    <li>
-                        <a href="/projects/Django/3.2/django.views.generic.base/ContextMixin/" class="">
-                            ContextMixin
-                        </a>
-                    </li>
-                    
+                <li>
+                    <a href="/projects/Django/3.2/django.views.generic.edit/BaseFormView/" class="direct">
+                        BaseFormView
+                    </a>
+                </li>
                 
-                    
-                    <li>
-                        <a href="/projects/Django/3.2/django.views.generic.edit/ProcessFormView/" class="">
-                            ProcessFormView
-                        </a>
-                    </li>
-                    
+            
                 
-                    
-                    <li>
-                        <a href="/projects/Django/3.2/django.views.generic.base/View/" class="">
-                            View
-                        </a>
-                    </li>
-                    </ol></div>
+                <li>
+                    <a href="/projects/Django/3.2/django.views.generic.edit/FormMixin/" class="">
+                        FormMixin
+                    </a>
+                </li>
                 
+            
+                
+                <li>
+                    <a href="/projects/Django/3.2/django.views.generic.base/ContextMixin/" class="">
+                        ContextMixin
+                    </a>
+                </li>
+                
+            
+                
+                <li>
+                    <a href="/projects/Django/3.2/django.views.generic.edit/ProcessFormView/" class="">
+                        ProcessFormView
+                    </a>
+                </li>
+                
+            
+                
+                <li>
+                    <a href="/projects/Django/3.2/django.views.generic.base/View/" class="">
+                        View
+                    </a>
+                </li>
+                </ol></div>
+            
 
+            
                 
-                    
-                    <div id="descendants" class="span8">
-                    <h2>Descendants</h2>
-                    <ul class="unstyled">
-                    
-                        <li><a href="/projects/Django/3.2/django.contrib.auth.views/LoginView/">LoginView</a></li>
-                    
+                <div id="descendants" class="span8">
+                <h2>Descendants</h2>
+                <ul class="unstyled">
                 
-                    
-                        <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
-                    
+                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/LoginView/">LoginView</a></li>
                 
-                    
-                        <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
-                    
+            
                 
-                    
-                        <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
-                    </ul></div>
+                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
                 
+            
+                
+                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
+                
+            
+                
+                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
+                </ul></div>
+            
         </div>
 
         <div class="row">

--- a/tests/_page_snapshots/fuzzy-klass-detail-old.html
+++ b/tests/_page_snapshots/fuzzy-klass-detail-old.html
@@ -407,7 +407,6 @@
             <div class="row">
     <div class="span12">
         <div class="row">
-            
                 
                     
                         <div class="span4">
@@ -484,7 +483,6 @@
                         <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
                     </ul></div>
                 
-            
         </div>
 
         <div class="row">

--- a/tests/_page_snapshots/fuzzy-klass-detail.html
+++ b/tests/_page_snapshots/fuzzy-klass-detail.html
@@ -408,80 +408,66 @@
     <div class="span12">
         <div class="row">
             
-                
-                    <div class="span4">
+                <div class="span4">
                     <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
                     <ol start='0' id="ancestors">
-                    <li><strong>FormView</strong></li>
-                
-                <li>
-                    <a href="/projects/Django/4.0/django.views.generic.base/TemplateResponseMixin/" class="direct">
-                        TemplateResponseMixin
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/4.0/django.views.generic.edit/BaseFormView/" class="direct">
-                        BaseFormView
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/4.0/django.views.generic.edit/FormMixin/" class="">
-                        FormMixin
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/4.0/django.views.generic.base/ContextMixin/" class="">
-                        ContextMixin
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/4.0/django.views.generic.edit/ProcessFormView/" class="">
-                        ProcessFormView
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/4.0/django.views.generic.base/View/" class="">
-                        View
-                    </a>
-                </li>
-                </ol></div>
+                        <li><strong>FormView</strong></li>
+                        
+                            <li>
+                                <a href="/projects/Django/4.0/django.views.generic.base/TemplateResponseMixin/" class="direct">
+                                    TemplateResponseMixin
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/4.0/django.views.generic.edit/BaseFormView/" class="direct">
+                                    BaseFormView
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/4.0/django.views.generic.edit/FormMixin/" class="">
+                                    FormMixin
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/4.0/django.views.generic.base/ContextMixin/" class="">
+                                    ContextMixin
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/4.0/django.views.generic.edit/ProcessFormView/" class="">
+                                    ProcessFormView
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/4.0/django.views.generic.base/View/" class="">
+                                    View
+                                </a>
+                            </li>
+                        
+                    </ol>
+                </div>
             
 
             
-                
                 <div id="descendants" class="span8">
-                <h2>Descendants</h2>
-                <ul class="unstyled">
-                
-                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a></li>
-                
-            
-                
-                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
-                
-            
-                
-                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
-                
-            
-                
-                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
-                </ul></div>
+                    <h2>Descendants</h2>
+                    <ul class="unstyled">
+                        
+                            <li><a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a></li>
+                        
+                            <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
+                        
+                            <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
+                        
+                            <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
+                        
+                    </ul>
+                </div>
             
         </div>
 

--- a/tests/_page_snapshots/fuzzy-klass-detail.html
+++ b/tests/_page_snapshots/fuzzy-klass-detail.html
@@ -407,82 +407,82 @@
             <div class="row">
     <div class="span12">
         <div class="row">
+            
                 
-                    
-                        <div class="span4">
-                        <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
-                        <ol start='0' id="ancestors">
-                        <li><strong>FormView</strong></li>
-                    
-                    <li>
-                        <a href="/projects/Django/4.0/django.views.generic.base/TemplateResponseMixin/" class="direct">
-                            TemplateResponseMixin
-                        </a>
-                    </li>
-                    
+                    <div class="span4">
+                    <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
+                    <ol start='0' id="ancestors">
+                    <li><strong>FormView</strong></li>
                 
-                    
-                    <li>
-                        <a href="/projects/Django/4.0/django.views.generic.edit/BaseFormView/" class="direct">
-                            BaseFormView
-                        </a>
-                    </li>
-                    
+                <li>
+                    <a href="/projects/Django/4.0/django.views.generic.base/TemplateResponseMixin/" class="direct">
+                        TemplateResponseMixin
+                    </a>
+                </li>
                 
-                    
-                    <li>
-                        <a href="/projects/Django/4.0/django.views.generic.edit/FormMixin/" class="">
-                            FormMixin
-                        </a>
-                    </li>
-                    
+            
                 
-                    
-                    <li>
-                        <a href="/projects/Django/4.0/django.views.generic.base/ContextMixin/" class="">
-                            ContextMixin
-                        </a>
-                    </li>
-                    
+                <li>
+                    <a href="/projects/Django/4.0/django.views.generic.edit/BaseFormView/" class="direct">
+                        BaseFormView
+                    </a>
+                </li>
                 
-                    
-                    <li>
-                        <a href="/projects/Django/4.0/django.views.generic.edit/ProcessFormView/" class="">
-                            ProcessFormView
-                        </a>
-                    </li>
-                    
+            
                 
-                    
-                    <li>
-                        <a href="/projects/Django/4.0/django.views.generic.base/View/" class="">
-                            View
-                        </a>
-                    </li>
-                    </ol></div>
+                <li>
+                    <a href="/projects/Django/4.0/django.views.generic.edit/FormMixin/" class="">
+                        FormMixin
+                    </a>
+                </li>
                 
+            
+                
+                <li>
+                    <a href="/projects/Django/4.0/django.views.generic.base/ContextMixin/" class="">
+                        ContextMixin
+                    </a>
+                </li>
+                
+            
+                
+                <li>
+                    <a href="/projects/Django/4.0/django.views.generic.edit/ProcessFormView/" class="">
+                        ProcessFormView
+                    </a>
+                </li>
+                
+            
+                
+                <li>
+                    <a href="/projects/Django/4.0/django.views.generic.base/View/" class="">
+                        View
+                    </a>
+                </li>
+                </ol></div>
+            
 
+            
                 
-                    
-                    <div id="descendants" class="span8">
-                    <h2>Descendants</h2>
-                    <ul class="unstyled">
-                    
-                        <li><a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a></li>
-                    
+                <div id="descendants" class="span8">
+                <h2>Descendants</h2>
+                <ul class="unstyled">
                 
-                    
-                        <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
-                    
+                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a></li>
                 
-                    
-                        <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
-                    
+            
                 
-                    
-                        <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
-                    </ul></div>
+                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
                 
+            
+                
+                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
+                
+            
+                
+                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
+                </ul></div>
+            
         </div>
 
         <div class="row">

--- a/tests/_page_snapshots/fuzzy-klass-detail.html
+++ b/tests/_page_snapshots/fuzzy-klass-detail.html
@@ -407,7 +407,6 @@
             <div class="row">
     <div class="span12">
         <div class="row">
-            
                 
                     
                         <div class="span4">
@@ -484,7 +483,6 @@
                         <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
                     </ul></div>
                 
-            
         </div>
 
         <div class="row">

--- a/tests/_page_snapshots/klass-detail-old.html
+++ b/tests/_page_snapshots/klass-detail-old.html
@@ -403,82 +403,82 @@
             <div class="row">
     <div class="span12">
         <div class="row">
+            
                 
-                    
-                        <div class="span4">
-                        <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
-                        <ol start='0' id="ancestors">
-                        <li><strong>FormView</strong></li>
-                    
-                    <li>
-                        <a href="/projects/Django/3.2/django.views.generic.base/TemplateResponseMixin/" class="direct">
-                            TemplateResponseMixin
-                        </a>
-                    </li>
-                    
+                    <div class="span4">
+                    <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
+                    <ol start='0' id="ancestors">
+                    <li><strong>FormView</strong></li>
                 
-                    
-                    <li>
-                        <a href="/projects/Django/3.2/django.views.generic.edit/BaseFormView/" class="direct">
-                            BaseFormView
-                        </a>
-                    </li>
-                    
+                <li>
+                    <a href="/projects/Django/3.2/django.views.generic.base/TemplateResponseMixin/" class="direct">
+                        TemplateResponseMixin
+                    </a>
+                </li>
                 
-                    
-                    <li>
-                        <a href="/projects/Django/3.2/django.views.generic.edit/FormMixin/" class="">
-                            FormMixin
-                        </a>
-                    </li>
-                    
+            
                 
-                    
-                    <li>
-                        <a href="/projects/Django/3.2/django.views.generic.base/ContextMixin/" class="">
-                            ContextMixin
-                        </a>
-                    </li>
-                    
+                <li>
+                    <a href="/projects/Django/3.2/django.views.generic.edit/BaseFormView/" class="direct">
+                        BaseFormView
+                    </a>
+                </li>
                 
-                    
-                    <li>
-                        <a href="/projects/Django/3.2/django.views.generic.edit/ProcessFormView/" class="">
-                            ProcessFormView
-                        </a>
-                    </li>
-                    
+            
                 
-                    
-                    <li>
-                        <a href="/projects/Django/3.2/django.views.generic.base/View/" class="">
-                            View
-                        </a>
-                    </li>
-                    </ol></div>
+                <li>
+                    <a href="/projects/Django/3.2/django.views.generic.edit/FormMixin/" class="">
+                        FormMixin
+                    </a>
+                </li>
                 
+            
+                
+                <li>
+                    <a href="/projects/Django/3.2/django.views.generic.base/ContextMixin/" class="">
+                        ContextMixin
+                    </a>
+                </li>
+                
+            
+                
+                <li>
+                    <a href="/projects/Django/3.2/django.views.generic.edit/ProcessFormView/" class="">
+                        ProcessFormView
+                    </a>
+                </li>
+                
+            
+                
+                <li>
+                    <a href="/projects/Django/3.2/django.views.generic.base/View/" class="">
+                        View
+                    </a>
+                </li>
+                </ol></div>
+            
 
+            
                 
-                    
-                    <div id="descendants" class="span8">
-                    <h2>Descendants</h2>
-                    <ul class="unstyled">
-                    
-                        <li><a href="/projects/Django/3.2/django.contrib.auth.views/LoginView/">LoginView</a></li>
-                    
+                <div id="descendants" class="span8">
+                <h2>Descendants</h2>
+                <ul class="unstyled">
                 
-                    
-                        <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
-                    
+                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/LoginView/">LoginView</a></li>
                 
-                    
-                        <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
-                    
+            
                 
-                    
-                        <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
-                    </ul></div>
+                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
                 
+            
+                
+                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
+                
+            
+                
+                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
+                </ul></div>
+            
         </div>
 
         <div class="row">

--- a/tests/_page_snapshots/klass-detail-old.html
+++ b/tests/_page_snapshots/klass-detail-old.html
@@ -403,7 +403,6 @@
             <div class="row">
     <div class="span12">
         <div class="row">
-            
                 
                     
                         <div class="span4">
@@ -480,7 +479,6 @@
                         <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
                     </ul></div>
                 
-            
         </div>
 
         <div class="row">

--- a/tests/_page_snapshots/klass-detail-old.html
+++ b/tests/_page_snapshots/klass-detail-old.html
@@ -404,80 +404,66 @@
     <div class="span12">
         <div class="row">
             
-                
-                    <div class="span4">
+                <div class="span4">
                     <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
                     <ol start='0' id="ancestors">
-                    <li><strong>FormView</strong></li>
-                
-                <li>
-                    <a href="/projects/Django/3.2/django.views.generic.base/TemplateResponseMixin/" class="direct">
-                        TemplateResponseMixin
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/3.2/django.views.generic.edit/BaseFormView/" class="direct">
-                        BaseFormView
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/3.2/django.views.generic.edit/FormMixin/" class="">
-                        FormMixin
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/3.2/django.views.generic.base/ContextMixin/" class="">
-                        ContextMixin
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/3.2/django.views.generic.edit/ProcessFormView/" class="">
-                        ProcessFormView
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/3.2/django.views.generic.base/View/" class="">
-                        View
-                    </a>
-                </li>
-                </ol></div>
+                        <li><strong>FormView</strong></li>
+                        
+                            <li>
+                                <a href="/projects/Django/3.2/django.views.generic.base/TemplateResponseMixin/" class="direct">
+                                    TemplateResponseMixin
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/3.2/django.views.generic.edit/BaseFormView/" class="direct">
+                                    BaseFormView
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/3.2/django.views.generic.edit/FormMixin/" class="">
+                                    FormMixin
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/3.2/django.views.generic.base/ContextMixin/" class="">
+                                    ContextMixin
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/3.2/django.views.generic.edit/ProcessFormView/" class="">
+                                    ProcessFormView
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/3.2/django.views.generic.base/View/" class="">
+                                    View
+                                </a>
+                            </li>
+                        
+                    </ol>
+                </div>
             
 
             
-                
                 <div id="descendants" class="span8">
-                <h2>Descendants</h2>
-                <ul class="unstyled">
-                
-                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/LoginView/">LoginView</a></li>
-                
-            
-                
-                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
-                
-            
-                
-                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
-                
-            
-                
-                    <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
-                </ul></div>
+                    <h2>Descendants</h2>
+                    <ul class="unstyled">
+                        
+                            <li><a href="/projects/Django/3.2/django.contrib.auth.views/LoginView/">LoginView</a></li>
+                        
+                            <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
+                        
+                            <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
+                        
+                            <li><a href="/projects/Django/3.2/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
+                        
+                    </ul>
+                </div>
             
         </div>
 

--- a/tests/_page_snapshots/klass-detail.html
+++ b/tests/_page_snapshots/klass-detail.html
@@ -404,80 +404,66 @@
     <div class="span12">
         <div class="row">
             
-                
-                    <div class="span4">
+                <div class="span4">
                     <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
                     <ol start='0' id="ancestors">
-                    <li><strong>FormView</strong></li>
-                
-                <li>
-                    <a href="/projects/Django/4.0/django.views.generic.base/TemplateResponseMixin/" class="direct">
-                        TemplateResponseMixin
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/4.0/django.views.generic.edit/BaseFormView/" class="direct">
-                        BaseFormView
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/4.0/django.views.generic.edit/FormMixin/" class="">
-                        FormMixin
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/4.0/django.views.generic.base/ContextMixin/" class="">
-                        ContextMixin
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/4.0/django.views.generic.edit/ProcessFormView/" class="">
-                        ProcessFormView
-                    </a>
-                </li>
-                
-            
-                
-                <li>
-                    <a href="/projects/Django/4.0/django.views.generic.base/View/" class="">
-                        View
-                    </a>
-                </li>
-                </ol></div>
+                        <li><strong>FormView</strong></li>
+                        
+                            <li>
+                                <a href="/projects/Django/4.0/django.views.generic.base/TemplateResponseMixin/" class="direct">
+                                    TemplateResponseMixin
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/4.0/django.views.generic.edit/BaseFormView/" class="direct">
+                                    BaseFormView
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/4.0/django.views.generic.edit/FormMixin/" class="">
+                                    FormMixin
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/4.0/django.views.generic.base/ContextMixin/" class="">
+                                    ContextMixin
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/4.0/django.views.generic.edit/ProcessFormView/" class="">
+                                    ProcessFormView
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/projects/Django/4.0/django.views.generic.base/View/" class="">
+                                    View
+                                </a>
+                            </li>
+                        
+                    </ol>
+                </div>
             
 
             
-                
                 <div id="descendants" class="span8">
-                <h2>Descendants</h2>
-                <ul class="unstyled">
-                
-                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a></li>
-                
-            
-                
-                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
-                
-            
-                
-                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
-                
-            
-                
-                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
-                </ul></div>
+                    <h2>Descendants</h2>
+                    <ul class="unstyled">
+                        
+                            <li><a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a></li>
+                        
+                            <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
+                        
+                            <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
+                        
+                            <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
+                        
+                    </ul>
+                </div>
             
         </div>
 

--- a/tests/_page_snapshots/klass-detail.html
+++ b/tests/_page_snapshots/klass-detail.html
@@ -403,82 +403,82 @@
             <div class="row">
     <div class="span12">
         <div class="row">
+            
                 
-                    
-                        <div class="span4">
-                        <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
-                        <ol start='0' id="ancestors">
-                        <li><strong>FormView</strong></li>
-                    
-                    <li>
-                        <a href="/projects/Django/4.0/django.views.generic.base/TemplateResponseMixin/" class="direct">
-                            TemplateResponseMixin
-                        </a>
-                    </li>
-                    
+                    <div class="span4">
+                    <h2>Ancestors (<abbr title="Method Resolution Order">MRO</abbr>)</h2>
+                    <ol start='0' id="ancestors">
+                    <li><strong>FormView</strong></li>
                 
-                    
-                    <li>
-                        <a href="/projects/Django/4.0/django.views.generic.edit/BaseFormView/" class="direct">
-                            BaseFormView
-                        </a>
-                    </li>
-                    
+                <li>
+                    <a href="/projects/Django/4.0/django.views.generic.base/TemplateResponseMixin/" class="direct">
+                        TemplateResponseMixin
+                    </a>
+                </li>
                 
-                    
-                    <li>
-                        <a href="/projects/Django/4.0/django.views.generic.edit/FormMixin/" class="">
-                            FormMixin
-                        </a>
-                    </li>
-                    
+            
                 
-                    
-                    <li>
-                        <a href="/projects/Django/4.0/django.views.generic.base/ContextMixin/" class="">
-                            ContextMixin
-                        </a>
-                    </li>
-                    
+                <li>
+                    <a href="/projects/Django/4.0/django.views.generic.edit/BaseFormView/" class="direct">
+                        BaseFormView
+                    </a>
+                </li>
                 
-                    
-                    <li>
-                        <a href="/projects/Django/4.0/django.views.generic.edit/ProcessFormView/" class="">
-                            ProcessFormView
-                        </a>
-                    </li>
-                    
+            
                 
-                    
-                    <li>
-                        <a href="/projects/Django/4.0/django.views.generic.base/View/" class="">
-                            View
-                        </a>
-                    </li>
-                    </ol></div>
+                <li>
+                    <a href="/projects/Django/4.0/django.views.generic.edit/FormMixin/" class="">
+                        FormMixin
+                    </a>
+                </li>
                 
+            
+                
+                <li>
+                    <a href="/projects/Django/4.0/django.views.generic.base/ContextMixin/" class="">
+                        ContextMixin
+                    </a>
+                </li>
+                
+            
+                
+                <li>
+                    <a href="/projects/Django/4.0/django.views.generic.edit/ProcessFormView/" class="">
+                        ProcessFormView
+                    </a>
+                </li>
+                
+            
+                
+                <li>
+                    <a href="/projects/Django/4.0/django.views.generic.base/View/" class="">
+                        View
+                    </a>
+                </li>
+                </ol></div>
+            
 
+            
                 
-                    
-                    <div id="descendants" class="span8">
-                    <h2>Descendants</h2>
-                    <ul class="unstyled">
-                    
-                        <li><a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a></li>
-                    
+                <div id="descendants" class="span8">
+                <h2>Descendants</h2>
+                <ul class="unstyled">
                 
-                    
-                        <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
-                    
+                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/LoginView/">LoginView</a></li>
                 
-                    
-                        <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
-                    
+            
                 
-                    
-                        <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
-                    </ul></div>
+                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordChangeView/">PasswordChangeView</a></li>
                 
+            
+                
+                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetConfirmView/">PasswordResetConfirmView</a></li>
+                
+            
+                
+                    <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
+                </ul></div>
+            
         </div>
 
         <div class="row">

--- a/tests/_page_snapshots/klass-detail.html
+++ b/tests/_page_snapshots/klass-detail.html
@@ -403,7 +403,6 @@
             <div class="row">
     <div class="span12">
         <div class="row">
-            
                 
                     
                         <div class="span4">
@@ -480,7 +479,6 @@
                         <li><a href="/projects/Django/4.0/django.contrib.auth.views/PasswordResetView/">PasswordResetView</a></li>
                     </ul></div>
                 
-            
         </div>
 
         <div class="row">


### PR DESCRIPTION
We rely a lot upon the storage classes in our templates.

This takes some steps to factor out some uses of them, and replace them with Plain Old Python Objects.

The views are getting heavier as a result, which isn't desirable, but this is one step of a larger refactor which will take that into account at a later stage.
