### PR TITLE
Fix HTML test snapshots

### DIFF
--- a/tests/_page_snapshots/fuzzy-klass-detail-old.html
+++ b/tests/_page_snapshots/fuzzy-klass-detail-old.html
@@ -13,6 +13,10 @@
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon/favicon.ico" sizes="48x48" />
+    <link rel="icon" href="/favicon/favicon.svg" sizes="any" type="image/svg+xml" />
+
     <!-- Le styles from Twitter Bootstrap-->
     <link href="/bootstrap.css" rel="stylesheet">
     <link href="/bootstrap-responsive.css" rel="stylesheet">

--- a/tests/_page_snapshots/fuzzy-klass-detail.html
+++ b/tests/_page_snapshots/fuzzy-klass-detail.html
@@ -13,6 +13,10 @@
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon/favicon.ico" sizes="48x48" />
+    <link rel="icon" href="/favicon/favicon.svg" sizes="any" type="image/svg+xml" />
+
     <!-- Le styles from Twitter Bootstrap-->
     <link href="/bootstrap.css" rel="stylesheet">
     <link href="/bootstrap-responsive.css" rel="stylesheet">

--- a/tests/_page_snapshots/fuzzy-module-detail.html
+++ b/tests/_page_snapshots/fuzzy-module-detail.html
@@ -8,6 +8,10 @@
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon/favicon.ico" sizes="48x48" />
+    <link rel="icon" href="/favicon/favicon.svg" sizes="any" type="image/svg+xml" />
+
     <!-- Le styles from Twitter Bootstrap-->
     <link href="/bootstrap.css" rel="stylesheet">
     <link href="/bootstrap-responsive.css" rel="stylesheet">

--- a/tests/_page_snapshots/homepage.html
+++ b/tests/_page_snapshots/homepage.html
@@ -8,6 +8,10 @@
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon/favicon.ico" sizes="48x48" />
+    <link rel="icon" href="/favicon/favicon.svg" sizes="any" type="image/svg+xml" />
+
     <!-- Le styles from Twitter Bootstrap-->
     <link href="/bootstrap.css" rel="stylesheet">
     <link href="/bootstrap-responsive.css" rel="stylesheet">

--- a/tests/_page_snapshots/klass-detail-old.html
+++ b/tests/_page_snapshots/klass-detail-old.html
@@ -13,6 +13,10 @@
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon/favicon.ico" sizes="48x48" />
+    <link rel="icon" href="/favicon/favicon.svg" sizes="any" type="image/svg+xml" />
+
     <!-- Le styles from Twitter Bootstrap-->
     <link href="/bootstrap.css" rel="stylesheet">
     <link href="/bootstrap-responsive.css" rel="stylesheet">

--- a/tests/_page_snapshots/klass-detail.html
+++ b/tests/_page_snapshots/klass-detail.html
@@ -13,6 +13,10 @@
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon/favicon.ico" sizes="48x48" />
+    <link rel="icon" href="/favicon/favicon.svg" sizes="any" type="image/svg+xml" />
+
     <!-- Le styles from Twitter Bootstrap-->
     <link href="/bootstrap.css" rel="stylesheet">
     <link href="/bootstrap-responsive.css" rel="stylesheet">

--- a/tests/_page_snapshots/module-detail.html
+++ b/tests/_page_snapshots/module-detail.html
@@ -8,6 +8,10 @@
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon/favicon.ico" sizes="48x48" />
+    <link rel="icon" href="/favicon/favicon.svg" sizes="any" type="image/svg+xml" />
+
     <!-- Le styles from Twitter Bootstrap-->
     <link href="/bootstrap.css" rel="stylesheet">
     <link href="/bootstrap-responsive.css" rel="stylesheet">

--- a/tests/_page_snapshots/version-detail.html
+++ b/tests/_page_snapshots/version-detail.html
@@ -10,6 +10,10 @@
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon/favicon.ico" sizes="48x48" />
+    <link rel="icon" href="/favicon/favicon.svg" sizes="any" type="image/svg+xml" />
+
     <!-- Le styles from Twitter Bootstrap-->
     <link href="/bootstrap.css" rel="stylesheet">
     <link href="/bootstrap-responsive.css" rel="stylesheet">


### PR DESCRIPTION
When [the favicon was added](https://github.com/classy-python/ccbv/pull/240) this test broke, as it should have done.

This fixes the snapshots to include the new favicons.