### PR TITLE
refactor: update KlassDetailView by converting ancestors to set

### DIFF
--- a/cbv/views.py
+++ b/cbv/views.py
@@ -56,7 +56,7 @@ class KlassDetailView(TemplateView):
         nav = nav_builder.get_nav_data(
             klass.module.project_version, klass.module, klass
         )
-        direct_ancestors = list(klass.get_ancestors())
+        direct_ancestors = set(klass.get_ancestors())
         ancestors = [
             self.Ancestor(
                 name=ancestor.name,


### PR DESCRIPTION
This PR enhances the `KlassDetailView` in `cbv/views.py` by making a small but effective change. The original code converted `klass.get_ancestors()` to a list:

```diff
-        direct_ancestors = list(klass.get_ancestors())
+        direct_ancestors = set(klass.get_ancestors())
```

I made this because in the next command we have a `ancestor in direct_ancestors`

```python
       direct_ancestors = set(klass.get_ancestors())
        ancestors = [
            self.Ancestor(
                name=ancestor.name,
                url=ancestor.get_absolute_url(),
                is_direct=ancestor in direct_ancestors,
            )
            for ancestor in klass.get_all_ancestors()
        ]
```

#### Why This Change?

1. Performance: Converting to a set instead of a list improves lookup efficiency. Sets offer O(1) membership testing compared to O(n) for lists, which is beneficial when direct_ancestors is use in lookups.
2. No Logic Change: The core behavior remains identical—only the data structure is optimized. This ensures stability while boosting performance.

Though the performance gain might not be dramatic for small datasets, this change is a proactive step toward scalability and cleaner code