### PR TITLE
Use pytest's parametrize instead of subtests

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -7,5 +7,4 @@ mypy-json-report>=0.1.3
 pre-commit
 pytest
 pytest-django
-pytest-subtests
 types-requests

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -50,10 +50,7 @@ pytest==7.1.2
     # via
     #   -r requirements.dev.in
     #   pytest-django
-    #   pytest-subtests
 pytest-django==4.5.2
-    # via -r requirements.dev.in
-pytest-subtests==0.8.0
     # via -r requirements.dev.in
 python-dateutil==2.8.2
     # via faker


### PR DESCRIPTION
Our use of subtests didn't remove much setup for the tests, but made it harder to target specific iterations of the tests.

Since the structure we were looping to perform the subtests fits perfectly with pytest's `parametrize` I've switched us to that.  The main benefit here is that you can target each test now, using the test ids defined in the parametrize mark, for example, this is now a valid pytest invocation:

    pytest tests/test_page_snapshots.py::test_page_html[klass-detail.html]

This format of test name will also be printed when tests fail, so a developer can see which templates failed in the output.