### PR TITLE
Upgrade coverage 6.5.0 -> 7.8.0

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,7 +6,7 @@ attrs==21.4.0
     #   pytest
 cfgv==3.3.1
     # via pre-commit
-coverage==6.5.0
+coverage==7.8.0
     # via -r requirements.dev.in
 distlib==0.3.9
     # via virtualenv


### PR DESCRIPTION
We're not far behind on this one, but we'll get wheels for more recent Python versions by moving to it.