### PR TITLE
Upgrade pyyaml 6.0.1 -> 6.0.2

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -48,7 +48,7 @@ pytest-django==4.5.2
     # via -r requirements.dev.in
 python-dateutil==2.8.2
     # via faker
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via pre-commit
 six==1.16.0
     # via


### PR DESCRIPTION
We're not far behind on this one, but we'll get wheels for more recent Python versions by moving to it.