### PR TITLE
Don't output pinned requirements to the terminal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ run-prod:
 	gunicorn core.wsgi --log-file -
 
 compile: _uv
-	uv pip compile requirements.prod.in --output-file=requirements.prod.txt
-	uv pip compile requirements.dev.in --output-file=requirements.dev.txt
+	uv pip compile --quiet requirements.prod.in --output-file=requirements.prod.txt
+	uv pip compile --quiet requirements.dev.in --output-file=requirements.dev.txt


### PR DESCRIPTION
This stops `uv pip compile` from outputting the pinned requirements to the terminal.  The output is quite verbose, doesn't tell you what's changed, and is already being written to `requirements.*.txt`, it's noise that I don't think we need.

I really should have done this before all the version upgrades, ho hum.