### PR TITLE
Add alternative build command for prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,14 @@ build: _uv
 	python manage.py migrate
 	python manage.py load_all_django_versions
 
+build-prod: _uv
+	uv pip install -r requirements.prod.txt
+	rm -rf staticfiles/*
+	python manage.py collectstatic --no-input
+	rm -f ccbv.sqlite
+	python manage.py migrate
+	python manage.py load_all_django_versions
+
 run-prod:
 	gunicorn core.wsgi --log-file -
 


### PR DESCRIPTION
A dev dependency (distlib) is failing to install on deploy.

Seeing as we shouldn't need dev dependencies in prod, I hope the issue can be avoided by installing fewer packages in prod.

This duplicates the `make build` script into `make build-prod`, and omits the installation of the dev dependencies.