### PR TITLE
Create and activate a virtualenv with uv in prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ build: _uv
 	python manage.py load_all_django_versions
 
 build-prod: _uv
+	uv venv --python 3.13
+	source .venv/bin/activate
 	uv pip install -r requirements.prod.txt
 	rm -rf staticfiles/*
 	python manage.py collectstatic --no-input


### PR DESCRIPTION
Logs show that Render is trying to install in the wrong directory:

```
...
uv pip install -r requirements.prod.txt
Using Python 3.13.4 environment at: /usr/local
...
```

Hopefully this will ensure we install in the correct place, and avoid the "read only filesystem" error I've been seeing.