### PR TITLE
Fix missing newlines

### DIFF
--- a/cbv/importer/importers.py
+++ b/cbv/importer/importers.py
@@ -1,6 +1,7 @@
 import importlib
 import inspect
 import sys
+import textwrap
 from collections.abc import Iterator
 from typing import Protocol
 
@@ -185,12 +186,10 @@ def _full_path(klass: type) -> str:
 def get_code(member):
     # Strip unneeded whitespace from beginning of code lines
     lines, start_line = inspect.getsourcelines(member)
-    whitespace = len(lines[0]) - len(lines[0].lstrip())
-    for i, line in enumerate(lines):
-        lines[i] = line[whitespace:]
 
     # Join code lines into one string
     code = "".join(lines)
+    code = textwrap.dedent(code)
 
     # Get the method arguments
     arguments = inspect.formatargspec(*inspect.getfullargspec(member))


### PR DESCRIPTION
This should fix the issue causing #164.

Newlines were lost when unindenting lines, because empty lines lost their newline character and were then joined to the others as just an empty string. I swapped the entire thing out for [textwrap.dedent](https://docs.python.org/3/library/textwrap.html).

With the data already in the JSON fixtures though: how far back do we want to fix this?