### PR TITLE
Make code side-scroll on smaller screens

### DIFF
--- a/cbv/static/style.css
+++ b/cbv/static/style.css
@@ -47,6 +47,14 @@ html {overflow-y: scroll;}
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
 }
+.highlighttable pre {
+  white-space: preserve nowrap;
+}
+.highlighttable td.code pre {
+  max-width: calc(100vw - 100px);
+  display: block;
+  overflow-x: auto;
+}
 .page-header .docstring {
     margin-bottom: 0;
 }


### PR DESCRIPTION
Fixes #79 by making code side-scroll on smaller screens (no changes on larger screens).

<img width="404" height="459" alt="2025-10-01T13:56:39+02:00" src="https://github.com/user-attachments/assets/e81e1348-e369-4468-af39-5205ee99ffef" />
